### PR TITLE
[feat] 소셜 로그인 + JWT 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.1.7'
+	id 'org.springframework.boot' version '3.2.0'
 	id 'io.spring.dependency-management' version '1.1.4'
 }
 
@@ -54,7 +54,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	// Social Login
-	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.0.3'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.0'
 }
 
 tasks.named('bootBuildImage') {

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ dependencies {
 	// Spring
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
+	// Validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	// Database
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,11 @@ dependencies {
 
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('bootBuildImage') {

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// Social Login
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.0.3'
 }
 
 tasks.named('bootBuildImage') {

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ dependencies {
 
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
+	// Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/org/pingle/pingleserver/PingleserverApplication.java
+++ b/src/main/java/org/pingle/pingleserver/PingleserverApplication.java
@@ -2,8 +2,9 @@ package org.pingle.pingleserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {UserDetailsServiceAutoConfiguration.class})
 public class PingleserverApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/pingle/pingleserver/annotation/UserId.java
+++ b/src/main/java/org/pingle/pingleserver/annotation/UserId.java
@@ -1,0 +1,11 @@
+package org.pingle.pingleserver.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserId {
+}

--- a/src/main/java/org/pingle/pingleserver/config/FeignClientConfig.java
+++ b/src/main/java/org/pingle/pingleserver/config/FeignClientConfig.java
@@ -1,0 +1,10 @@
+package org.pingle.pingleserver.config;
+
+import org.pingle.pingleserver.PingleserverApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackageClasses = PingleserverApplication.class)
+public class FeignClientConfig {
+}

--- a/src/main/java/org/pingle/pingleserver/config/WebMVCConfig.java
+++ b/src/main/java/org/pingle/pingleserver/config/WebMVCConfig.java
@@ -1,0 +1,23 @@
+package org.pingle.pingleserver.config;
+
+import lombok.RequiredArgsConstructor;
+import org.pingle.pingleserver.interceptor.pre.UserIdArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@EnableWebMvc
+@RequiredArgsConstructor
+public class WebMVCConfig implements WebMvcConfigurer {
+    private final UserIdArgumentResolver userIdArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        WebMvcConfigurer.super.addArgumentResolvers(resolvers);
+        resolvers.add(this.userIdArgumentResolver);
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/constant/Constants.java
+++ b/src/main/java/org/pingle/pingleserver/constant/Constants.java
@@ -1,0 +1,9 @@
+package org.pingle.pingleserver.constant;
+
+public class Constants {
+    public static String USER_ID_CLAIM_NAME = "uid";
+    public static String USER_ROLE_CLAIM_NAME = "rol";
+    public static String BEARER_PREFIX = "Bearer ";
+    public static String AUTHORIZATION_HEADER = "Authorization";
+
+}

--- a/src/main/java/org/pingle/pingleserver/controller/AuthController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/AuthController.java
@@ -1,5 +1,6 @@
 package org.pingle.pingleserver.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.pingle.pingleserver.dto.common.ApiResponse;
 import org.pingle.pingleserver.dto.request.LoginRequest;
@@ -18,7 +19,7 @@ public class AuthController {
     @PostMapping("/login")
     public ApiResponse<JwtTokenResponse> login(
             @RequestHeader("Provider-Token") String providerToken,
-            @RequestBody LoginRequest request){
+            @Valid @RequestBody LoginRequest request){
         return ApiResponse.success(SuccessMessage.OK, authService.login(providerToken, request));
     }
 }

--- a/src/main/java/org/pingle/pingleserver/controller/AuthController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/AuthController.java
@@ -9,7 +9,7 @@ import org.pingle.pingleserver.service.AuthService;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("api/auth")
+@RequestMapping("v1/auth")
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/src/main/java/org/pingle/pingleserver/controller/AuthController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/AuthController.java
@@ -2,6 +2,7 @@ package org.pingle.pingleserver.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.pingle.pingleserver.annotation.UserId;
 import org.pingle.pingleserver.dto.common.ApiResponse;
 import org.pingle.pingleserver.dto.request.LoginRequest;
 import org.pingle.pingleserver.dto.response.JwtTokenResponse;
@@ -10,7 +11,7 @@ import org.pingle.pingleserver.service.AuthService;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("v1/auth")
+@RequestMapping("/v1/auth")
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/src/main/java/org/pingle/pingleserver/controller/AuthController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/AuthController.java
@@ -1,0 +1,24 @@
+package org.pingle.pingleserver.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.pingle.pingleserver.dto.common.ApiResponse;
+import org.pingle.pingleserver.dto.request.LoginRequest;
+import org.pingle.pingleserver.dto.response.JwtTokenResponse;
+import org.pingle.pingleserver.dto.type.SuccessMessage;
+import org.pingle.pingleserver.service.AuthService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ApiResponse<JwtTokenResponse> login(
+            @RequestHeader("Provider-Token") String providerToken,
+            @RequestBody LoginRequest request){
+        return ApiResponse.success(SuccessMessage.OK, authService.login(providerToken, request));
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/controller/AuthController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/AuthController.java
@@ -1,8 +1,8 @@
 package org.pingle.pingleserver.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
-import org.pingle.pingleserver.annotation.UserId;
 import org.pingle.pingleserver.dto.common.ApiResponse;
 import org.pingle.pingleserver.dto.request.LoginRequest;
 import org.pingle.pingleserver.dto.response.JwtTokenResponse;
@@ -19,7 +19,7 @@ public class AuthController {
 
     @PostMapping("/login")
     public ApiResponse<JwtTokenResponse> login(
-            @RequestHeader("Provider-Token") String providerToken,
+            @NotNull @RequestHeader("Provider-Token") String providerToken,
             @Valid @RequestBody LoginRequest request){
         return ApiResponse.success(SuccessMessage.OK, authService.login(providerToken, request));
     }

--- a/src/main/java/org/pingle/pingleserver/controller/TestController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/TestController.java
@@ -1,0 +1,29 @@
+package org.pingle.pingleserver.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.pingle.pingleserver.annotation.UserId;
+import org.pingle.pingleserver.domain.enums.URole;
+import org.pingle.pingleserver.dto.response.JwtTokenResponse;
+import org.pingle.pingleserver.utils.JwtUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class TestController {
+
+    private final JwtUtil jwtUtil;
+    @GetMapping("/token")
+    public JwtTokenResponse testToken() {
+        return jwtUtil.generateTokens(1L, URole.ADMIN);
+    }
+
+    @GetMapping("/user-test")
+    public ResponseEntity<Long> testUser(@UserId Long userId) {
+        return ResponseEntity.ok(userId);
+    }
+
+}

--- a/src/main/java/org/pingle/pingleserver/controller/TestController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/TestController.java
@@ -8,11 +8,13 @@ import org.pingle.pingleserver.dto.response.JwtTokenResponse;
 import org.pingle.pingleserver.utils.JwtUtil;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/test")
 public class TestController {
 
     private final JwtUtil jwtUtil;

--- a/src/main/java/org/pingle/pingleserver/domain/User.java
+++ b/src/main/java/org/pingle/pingleserver/domain/User.java
@@ -51,6 +51,10 @@ public class User {
         this.refreshToken = refreshToken;
     }
 
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
     public void softDelete() {
         this.isDeleted = true;
         this.deletedAt = LocalDateTime.now().plusDays(MEMBER_INFO_RETENTION_PERIOD);

--- a/src/main/java/org/pingle/pingleserver/domain/User.java
+++ b/src/main/java/org/pingle/pingleserver/domain/User.java
@@ -2,15 +2,62 @@ package org.pingle.pingleserver.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.pingle.pingleserver.domain.enums.Provider;
+import org.pingle.pingleserver.domain.enums.URole;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Table(name = "users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User extends BaseTimeEntity {
+public class User {
+    private static final Long MEMBER_INFO_RETENTION_PERIOD = 180L;
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
+    private String serialId;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private URole role;
+
+    private String name;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Provider provider;
+
+    private String refreshToken;
+
+    private String email;
+
+    private boolean isDeleted = false;
+
+    private LocalDateTime deletedAt;
+
+    @Builder
+    public User(String serialId, String name, String email, Provider provider, URole role, String refreshToken) {
+        this.serialId = serialId;
+        this.name = name;
+        this.email = email;
+        this.provider = provider;
+        this.role = role;
+        this.refreshToken = refreshToken;
+    }
+
+    public void softDelete() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now().plusDays(MEMBER_INFO_RETENTION_PERIOD);
+    }
+
+    public void recover() {
+        this.isDeleted = false;
+        this.deletedAt = null;
+    }
 }

--- a/src/main/java/org/pingle/pingleserver/domain/enums/Provider.java
+++ b/src/main/java/org/pingle/pingleserver/domain/enums/Provider.java
@@ -1,0 +1,18 @@
+package org.pingle.pingleserver.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Provider {
+    KAKAO("KAKAO"),
+    APPLE("APPLE");
+
+    private final String name;
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/domain/enums/URole.java
+++ b/src/main/java/org/pingle/pingleserver/domain/enums/URole.java
@@ -1,0 +1,14 @@
+package org.pingle.pingleserver.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+
+@Getter
+@RequiredArgsConstructor
+public enum URole {
+    USER("USER"),
+    ADMIN("ADMIN");
+
+    private final String name;
+}

--- a/src/main/java/org/pingle/pingleserver/dto/request/LoginRequest.java
+++ b/src/main/java/org/pingle/pingleserver/dto/request/LoginRequest.java
@@ -1,0 +1,6 @@
+package org.pingle.pingleserver.dto.request;
+
+import org.pingle.pingleserver.domain.enums.Provider;
+
+public record LoginRequest(Provider provider) {
+}

--- a/src/main/java/org/pingle/pingleserver/dto/request/LoginRequest.java
+++ b/src/main/java/org/pingle/pingleserver/dto/request/LoginRequest.java
@@ -1,6 +1,7 @@
 package org.pingle.pingleserver.dto.request;
 
+import lombok.NonNull;
 import org.pingle.pingleserver.domain.enums.Provider;
 
-public record LoginRequest(Provider provider) {
+public record LoginRequest(@NonNull Provider provider, String name) {
 }

--- a/src/main/java/org/pingle/pingleserver/dto/request/LoginRequest.java
+++ b/src/main/java/org/pingle/pingleserver/dto/request/LoginRequest.java
@@ -1,7 +1,7 @@
 package org.pingle.pingleserver.dto.request;
 
-import lombok.NonNull;
+import jakarta.validation.constraints.NotNull;
 import org.pingle.pingleserver.domain.enums.Provider;
 
-public record LoginRequest(@NonNull Provider provider, String name) {
+public record LoginRequest(@NotNull Provider provider, String name) {
 }

--- a/src/main/java/org/pingle/pingleserver/dto/response/JwtTokenResponse.java
+++ b/src/main/java/org/pingle/pingleserver/dto/response/JwtTokenResponse.java
@@ -1,0 +1,13 @@
+package org.pingle.pingleserver.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record JwtTokenResponse (String accessToken, String refreshToken){
+    public static JwtTokenResponse of(String accessToken, String refreshToken) {
+        return JwtTokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/dto/response/JwtTokenResponse.java
+++ b/src/main/java/org/pingle/pingleserver/dto/response/JwtTokenResponse.java
@@ -1,9 +1,10 @@
 package org.pingle.pingleserver.dto.response;
 
 import lombok.Builder;
+import lombok.NonNull;
 
 @Builder
-public record JwtTokenResponse (String accessToken, String refreshToken){
+public record JwtTokenResponse (@NonNull String accessToken, @NonNull String refreshToken){
     public static JwtTokenResponse of(String accessToken, String refreshToken) {
         return JwtTokenResponse.builder()
                 .accessToken(accessToken)

--- a/src/main/java/org/pingle/pingleserver/dto/response/JwtTokenResponse.java
+++ b/src/main/java/org/pingle/pingleserver/dto/response/JwtTokenResponse.java
@@ -1,10 +1,10 @@
 package org.pingle.pingleserver.dto.response;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
-import lombok.NonNull;
 
 @Builder
-public record JwtTokenResponse (@NonNull String accessToken, @NonNull String refreshToken){
+public record JwtTokenResponse (@NotNull String accessToken, @NotNull String refreshToken){
     public static JwtTokenResponse of(String accessToken, String refreshToken) {
         return JwtTokenResponse.builder()
                 .accessToken(accessToken)

--- a/src/main/java/org/pingle/pingleserver/dto/type/ErrorMessage.java
+++ b/src/main/java/org/pingle/pingleserver/dto/type/ErrorMessage.java
@@ -21,6 +21,7 @@ public enum ErrorMessage {
     INVALID_HEADER_ERROR(HttpStatus.BAD_REQUEST, "유효하지 않은 헤더입니다."),
     INVALID_PROVIDER_ERROR(HttpStatus.BAD_REQUEST, "유효하지 않은 소셜 플랫폼입니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    MISSING_REQUIRED_HEADER(HttpStatus.BAD_REQUEST, "필수 헤더가 누락되었습니다."),
     // Authorization Error 401
     TOKEN_MALFORMED_ERROR(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     UNAUTHORIZED_ERROR(HttpStatus.UNAUTHORIZED, "토큰이 제공되지 않았거나 유효하지 않습니다."),

--- a/src/main/java/org/pingle/pingleserver/dto/type/ErrorMessage.java
+++ b/src/main/java/org/pingle/pingleserver/dto/type/ErrorMessage.java
@@ -7,8 +7,25 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorMessage {
+    // Apple Login Error
+    INVALID_APPLE_PUBLIC_KEY(HttpStatus.BAD_REQUEST, "유효하지 않은 Apple Public Key입니다."),
+    INVALID_APPLE_IDENTITY_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 Apple Identity Token입니다."),
+    EXPIRED_APPLE_IDENTITY_TOKEN(HttpStatus.BAD_REQUEST, "만료된 Apple Identity Token입니다."),
+    CREATE_PUBLIC_KEY_EXCEPTION(HttpStatus.BAD_REQUEST, "Apple Public verify에 실패했습니다."),
+    // JWT Error
+    INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다."),
+    EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
+    UNSUPPORTED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 JWT 토큰입니다."),
+    JWT_TOKEN_IS_EMPTY(HttpStatus.UNAUTHORIZED, "JWT 토큰이 비어있습니다."),
     // Invalid Argument Error 400
     INVALID_HEADER_ERROR(HttpStatus.BAD_REQUEST, "유효하지 않은 헤더입니다."),
+    INVALID_PROVIDER_ERROR(HttpStatus.BAD_REQUEST, "유효하지 않은 소셜 플랫폼입니다."),
+    // Authorization Error 401
+    TOKEN_MALFORMED_ERROR(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    LOGIN_FAIL_ERROR(HttpStatus.UNAUTHORIZED, "로그인에 실패했습니다."),
+    NO_SUCH_USER(HttpStatus.UNAUTHORIZED, "존재하지 않는 사용자입니다."),
+    // Not Found Error 404
+    USER_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     // Method Not Allowed Error 405
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메소드입니다."),
     // Internal Server Error 500

--- a/src/main/java/org/pingle/pingleserver/dto/type/ErrorMessage.java
+++ b/src/main/java/org/pingle/pingleserver/dto/type/ErrorMessage.java
@@ -20,12 +20,14 @@ public enum ErrorMessage {
     // Invalid Argument Error 400
     INVALID_HEADER_ERROR(HttpStatus.BAD_REQUEST, "유효하지 않은 헤더입니다."),
     INVALID_PROVIDER_ERROR(HttpStatus.BAD_REQUEST, "유효하지 않은 소셜 플랫폼입니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     // Authorization Error 401
     TOKEN_MALFORMED_ERROR(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
-    LOGIN_FAIL_ERROR(HttpStatus.UNAUTHORIZED, "로그인에 실패했습니다."),
+    UNAUTHORIZED_ERROR(HttpStatus.UNAUTHORIZED, "토큰이 제공되지 않았거나 유효하지 않습니다."),
     NO_SUCH_USER(HttpStatus.UNAUTHORIZED, "존재하지 않는 사용자입니다."),
     // Not Found Error 404
     USER_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND, "존재하지 않는 API입니다."),
     // Method Not Allowed Error 405
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메소드입니다."),
     // Internal Server Error 500

--- a/src/main/java/org/pingle/pingleserver/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/pingle/pingleserver/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
@@ -27,6 +28,13 @@ public class GlobalExceptionHandler {
         log.error("handlerMethodArgumentNotValidException() in GlobalExceptionHandler throw MethodArgumentNotValidException : {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ApiResponse.fail(ErrorMessage.BAD_REQUEST));
+    }
+
+    @ExceptionHandler(value = {MissingRequestHeaderException.class})
+    public ResponseEntity<ApiResponse<?>> handlerMissingRequestHeaderException(Exception e) {
+        log.error("handlerMissingRequestHeaderException() in GlobalExceptionHandler throw MissingRequestHeaderException : {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.fail(ErrorMessage.MISSING_REQUIRED_HEADER));
     }
 
     @ExceptionHandler(BusinessException.class)

--- a/src/main/java/org/pingle/pingleserver/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/pingle/pingleserver/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.pingle.pingleserver.dto.type.ErrorMessage;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
@@ -17,8 +18,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(value = {NoHandlerFoundException.class, HttpRequestMethodNotSupportedException.class})
     public ResponseEntity<ApiResponse<?>> handleNoPageFoundException(Exception e) {
         log.error("handleNoPageFoundException() in GlobalExceptionHandler throw NoHandlerFoundException : {}", e.getMessage());
-        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
-                .body(ApiResponse.fail(ErrorMessage.METHOD_NOT_ALLOWED));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.fail(ErrorMessage.NOT_FOUND_END_POINT));
+    }
+
+    @ExceptionHandler(value = {MethodArgumentNotValidException.class})
+    public ResponseEntity<ApiResponse<?>> handlerMethodArgumentNotValidException(Exception e) {
+        log.error("handlerMethodArgumentNotValidException() in GlobalExceptionHandler throw MethodArgumentNotValidException : {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.fail(ErrorMessage.BAD_REQUEST));
     }
 
     @ExceptionHandler(BusinessException.class)

--- a/src/main/java/org/pingle/pingleserver/interceptor/pre/UserIdArgumentResolver.java
+++ b/src/main/java/org/pingle/pingleserver/interceptor/pre/UserIdArgumentResolver.java
@@ -1,0 +1,37 @@
+package org.pingle.pingleserver.interceptor.pre;
+
+import lombok.extern.slf4j.Slf4j;
+import org.pingle.pingleserver.annotation.UserId;
+import org.pingle.pingleserver.dto.type.ErrorMessage;
+import org.pingle.pingleserver.exception.BusinessException;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.security.Principal;
+
+@Slf4j
+@Component
+public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(Long.class)
+                && parameter.hasParameterAnnotation(UserId.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        final Principal principal = webRequest.getUserPrincipal();
+        if (principal == null) {
+            throw new BusinessException(ErrorMessage.NO_SUCH_USER);
+        }
+        return Long.valueOf(principal.getName());
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/interceptor/pre/UserIdArgumentResolver.java
+++ b/src/main/java/org/pingle/pingleserver/interceptor/pre/UserIdArgumentResolver.java
@@ -30,7 +30,7 @@ public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
                                   WebDataBinderFactory binderFactory) {
         final Principal principal = webRequest.getUserPrincipal();
         if (principal == null) {
-            throw new BusinessException(ErrorMessage.NO_SUCH_USER);
+            throw new BusinessException(ErrorMessage.INVALID_JWT_TOKEN);
         }
         return Long.valueOf(principal.getName());
     }

--- a/src/main/java/org/pingle/pingleserver/oauth/client/AppleFeignClient.java
+++ b/src/main/java/org/pingle/pingleserver/oauth/client/AppleFeignClient.java
@@ -1,0 +1,12 @@
+package org.pingle.pingleserver.oauth.client;
+
+import org.pingle.pingleserver.oauth.dto.ApplePublicKeys;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "apple-public-verify-client", url = "https://appleid.apple.com/auth")
+public interface AppleFeignClient {
+
+    @GetMapping("/keys")
+    ApplePublicKeys getApplePublicKeys();
+}

--- a/src/main/java/org/pingle/pingleserver/oauth/client/KakaoFeignClient.java
+++ b/src/main/java/org/pingle/pingleserver/oauth/client/KakaoFeignClient.java
@@ -1,0 +1,13 @@
+package org.pingle.pingleserver.oauth.client;
+
+import org.pingle.pingleserver.oauth.dto.KakaoUserDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "kakaoFeignClient", url = "https://kapi.kakao.com")
+public interface KakaoFeignClient {
+    @GetMapping(value = "/v2/user/me")
+    KakaoUserDto getUserInformation(@RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken);
+}

--- a/src/main/java/org/pingle/pingleserver/oauth/dto/ApplePublicKey.java
+++ b/src/main/java/org/pingle/pingleserver/oauth/dto/ApplePublicKey.java
@@ -1,0 +1,7 @@
+package org.pingle.pingleserver.oauth.dto;
+
+public record ApplePublicKey(
+        String kty, String kid, String use, String alg, String n, String e, String email
+) {
+
+}

--- a/src/main/java/org/pingle/pingleserver/oauth/dto/ApplePublicKeys.java
+++ b/src/main/java/org/pingle/pingleserver/oauth/dto/ApplePublicKeys.java
@@ -1,0 +1,16 @@
+package org.pingle.pingleserver.oauth.dto;
+
+import org.pingle.pingleserver.dto.type.ErrorMessage;
+import org.pingle.pingleserver.exception.BusinessException;
+
+import java.util.List;
+
+public record ApplePublicKeys(List<ApplePublicKey> keys) {
+    public ApplePublicKey getMatchesKey(String alg, String kid) {
+        return this.keys
+                .stream()
+                .filter(k -> k.alg().equals(alg) && k.kid().equals(kid))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(ErrorMessage.INVALID_APPLE_PUBLIC_KEY));
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/oauth/dto/KakaoAccount.java
+++ b/src/main/java/org/pingle/pingleserver/oauth/dto/KakaoAccount.java
@@ -1,0 +1,8 @@
+package org.pingle.pingleserver.oauth.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KakaoAccount (KakaoUserProfile kakaoUserProfile){
+}

--- a/src/main/java/org/pingle/pingleserver/oauth/dto/KakaoUserDto.java
+++ b/src/main/java/org/pingle/pingleserver/oauth/dto/KakaoUserDto.java
@@ -1,0 +1,9 @@
+package org.pingle.pingleserver.oauth.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KakaoUserDto(Long id, KakaoAccount kakaoAccount){
+
+}

--- a/src/main/java/org/pingle/pingleserver/oauth/dto/KakaoUserProfile.java
+++ b/src/main/java/org/pingle/pingleserver/oauth/dto/KakaoUserProfile.java
@@ -1,0 +1,8 @@
+package org.pingle.pingleserver.oauth.dto;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KakaoUserProfile (String nickname, String email){
+
+}

--- a/src/main/java/org/pingle/pingleserver/oauth/dto/SocialInfoDto.java
+++ b/src/main/java/org/pingle/pingleserver/oauth/dto/SocialInfoDto.java
@@ -1,0 +1,7 @@
+package org.pingle.pingleserver.oauth.dto;
+
+public record SocialInfoDto (String serialId, String email, String name){
+    public static SocialInfoDto of(String serialId, String email, String name) {
+        return new SocialInfoDto(serialId, email, name);
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/oauth/service/AppleLoginService.java
+++ b/src/main/java/org/pingle/pingleserver/oauth/service/AppleLoginService.java
@@ -1,0 +1,31 @@
+package org.pingle.pingleserver.oauth.service;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.pingle.pingleserver.oauth.dto.ApplePublicKeys;
+import org.pingle.pingleserver.oauth.dto.SocialInfoDto;
+import org.pingle.pingleserver.oauth.client.AppleFeignClient;
+import org.pingle.pingleserver.oauth.verify.AppleJwtParser;
+import org.pingle.pingleserver.oauth.verify.PublicKeyGenerator;
+import org.springframework.stereotype.Service;
+
+import java.security.PublicKey;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AppleLoginService {
+
+    private final AppleFeignClient appleFeignClient;
+    private final AppleJwtParser appleJwtParser;
+    private final PublicKeyGenerator publicKeyGenerator;
+
+    public SocialInfoDto getInfo(String identityToken, String name) {
+        Map<String, String> headers = appleJwtParser.parseHeaders(identityToken);
+        ApplePublicKeys applePublicKeys = appleFeignClient.getApplePublicKeys();
+        PublicKey publicKey = publicKeyGenerator.generatePublicKey(headers, applePublicKeys);
+        Claims claims = appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey);
+        return SocialInfoDto.of(claims.get("email", String.class), claims.get("sub", String.class), name);
+    }
+
+}

--- a/src/main/java/org/pingle/pingleserver/oauth/service/KakaoLoginService.java
+++ b/src/main/java/org/pingle/pingleserver/oauth/service/KakaoLoginService.java
@@ -1,0 +1,20 @@
+package org.pingle.pingleserver.oauth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.pingle.pingleserver.oauth.dto.KakaoUserDto;
+import org.pingle.pingleserver.oauth.dto.SocialInfoDto;
+import org.pingle.pingleserver.oauth.client.KakaoFeignClient;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoLoginService {
+    private final KakaoFeignClient kakaoFeignClient;
+    public SocialInfoDto getInfo(String providerToken) {
+        KakaoUserDto kakaoUserdto = kakaoFeignClient.getUserInformation("Bearer " + providerToken);
+        return SocialInfoDto.of(
+                kakaoUserdto.id().toString(),
+                kakaoUserdto.kakaoAccount().kakaoUserProfile().email(),
+                kakaoUserdto.kakaoAccount().kakaoUserProfile().nickname());
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/oauth/verify/AppleJwtParser.java
+++ b/src/main/java/org/pingle/pingleserver/oauth/verify/AppleJwtParser.java
@@ -1,0 +1,47 @@
+package org.pingle.pingleserver.oauth.verify;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.*;
+import org.pingle.pingleserver.dto.type.ErrorMessage;
+import org.pingle.pingleserver.exception.BusinessException;
+import org.springframework.stereotype.Component;
+
+import java.security.PublicKey;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+public class AppleJwtParser {
+
+    private static final String IDENTITY_TOKEN_VALUE_DELIMITER = "\\.";
+    private static final int HEADER_INDEX = 0;
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public Map<String, String> parseHeaders(String identityToken) {
+        try {
+            String encodedHeader = identityToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[HEADER_INDEX];
+            String decodedHeader = new String(Base64.getUrlDecoder().decode(encodedHeader));
+            return OBJECT_MAPPER.readValue(decodedHeader, Map.class);
+
+        } catch (JsonProcessingException | ArrayIndexOutOfBoundsException e) {
+            throw new BusinessException(ErrorMessage.INVALID_APPLE_IDENTITY_TOKEN);
+        }
+    }
+
+    public Claims parsePublicKeyAndGetClaims(String idToken, PublicKey publicKey) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(publicKey)
+                    .build()
+                    .parseClaimsJws(idToken)
+                    .getBody();
+
+        } catch (ExpiredJwtException e) {
+            throw new BusinessException(ErrorMessage.EXPIRED_APPLE_IDENTITY_TOKEN);
+        } catch (UnsupportedJwtException | MalformedJwtException | IllegalArgumentException e) {
+            throw new BusinessException(ErrorMessage.INVALID_APPLE_IDENTITY_TOKEN);
+        }
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/oauth/verify/PublicKeyGenerator.java
+++ b/src/main/java/org/pingle/pingleserver/oauth/verify/PublicKeyGenerator.java
@@ -1,0 +1,49 @@
+package org.pingle.pingleserver.oauth.verify;
+
+import org.pingle.pingleserver.dto.type.ErrorMessage;
+import org.pingle.pingleserver.exception.BusinessException;
+import org.pingle.pingleserver.oauth.dto.ApplePublicKey;
+import org.pingle.pingleserver.oauth.dto.ApplePublicKeys;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+public class PublicKeyGenerator {
+
+    private static final String SIGN_ALGORITHM_HEADER_KEY = "alg";
+    private static final String KEY_ID_HEADER_KEY = "kid";
+    private static final int POSITIVE_SIGN_NUMBER = 1;
+
+    public PublicKey generatePublicKey(Map<String, String> headers, ApplePublicKeys applePublicKeys) {
+        ApplePublicKey applePublicKey =
+                applePublicKeys.getMatchesKey(headers.get(SIGN_ALGORITHM_HEADER_KEY), headers.get(KEY_ID_HEADER_KEY));
+
+        return generatePublicKeyWithApplePublicKey(applePublicKey);
+    }
+
+    private PublicKey generatePublicKeyWithApplePublicKey(ApplePublicKey publicKey) {
+        byte[] nBytes = Base64.getUrlDecoder().decode(publicKey.n());
+        byte[] eBytes = Base64.getUrlDecoder().decode(publicKey.e());
+
+        BigInteger n = new BigInteger(POSITIVE_SIGN_NUMBER, nBytes);
+        BigInteger e = new BigInteger(POSITIVE_SIGN_NUMBER, eBytes);
+
+        RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(n, e);
+
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance(publicKey.kty());
+            return keyFactory.generatePublic(publicKeySpec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException exception) {
+            throw new BusinessException(ErrorMessage.CREATE_PUBLIC_KEY_EXCEPTION);
+        }
+    }
+}
+

--- a/src/main/java/org/pingle/pingleserver/repository/UserRepository.java
+++ b/src/main/java/org/pingle/pingleserver/repository/UserRepository.java
@@ -1,7 +1,14 @@
 package org.pingle.pingleserver.repository;
 
 import org.pingle.pingleserver.domain.User;
+import org.pingle.pingleserver.domain.enums.Provider;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByProviderAndSerialIdAndIsDeleted(Provider provider, String serialId, Boolean deleted);
+    Optional<User> findByProviderAndSerialIdAndIsDeleted(Provider provider, String serialId, Boolean deleted);
+
 }

--- a/src/main/java/org/pingle/pingleserver/security/config/SecurityConfig.java
+++ b/src/main/java/org/pingle/pingleserver/security/config/SecurityConfig.java
@@ -1,0 +1,49 @@
+package org.pingle.pingleserver.security.config;
+
+import lombok.RequiredArgsConstructor;
+import org.pingle.pingleserver.security.filter.CustomJwtAuthenticationEntryPoint;
+import org.pingle.pingleserver.security.filter.JwtAuthenticationFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
+
+    private static final String[] AUTH_WHITELIST = {
+            "/auth/login",
+            "/auth/reissue",
+            "/token",
+            "/api-docs.html",
+            "/api-docs/**",
+            "/swagger-ui/**"
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(sessionManagementConfigurer ->
+                        sessionManagementConfigurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exceptionHandlingConfigurer ->
+                        exceptionHandlingConfigurer.authenticationEntryPoint(customJwtAuthenticationEntryPoint))
+                .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
+                        authorizationManagerRequestMatcherRegistry
+                                .requestMatchers(AUTH_WHITELIST).permitAll()
+                                .anyRequest().authenticated())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/security/config/SecurityConfig.java
+++ b/src/main/java/org/pingle/pingleserver/security/config/SecurityConfig.java
@@ -21,9 +21,9 @@ public class SecurityConfig {
     private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
 
     private static final String[] AUTH_WHITELIST = {
-            "v1/auth/login",
-            "v1/auth/reissue",
-            "/token",
+            "/v1/auth/login",
+            "/v1/auth/reissue",
+            "/test/**",
             "/api-docs.html",
             "/api-docs/**",
             "/swagger-ui/**"

--- a/src/main/java/org/pingle/pingleserver/security/config/SecurityConfig.java
+++ b/src/main/java/org/pingle/pingleserver/security/config/SecurityConfig.java
@@ -21,8 +21,8 @@ public class SecurityConfig {
     private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
 
     private static final String[] AUTH_WHITELIST = {
-            "/auth/login",
-            "/auth/reissue",
+            "v1/auth/login",
+            "v1/auth/reissue",
             "/token",
             "/api-docs.html",
             "/api-docs/**",

--- a/src/main/java/org/pingle/pingleserver/security/filter/CustomJwtAuthenticationEntryPoint.java
+++ b/src/main/java/org/pingle/pingleserver/security/filter/CustomJwtAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package org.pingle.pingleserver.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.pingle.pingleserver.dto.common.ApiResponse;
+import org.pingle.pingleserver.dto.type.ErrorMessage;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+@Slf4j
+@Component
+public class CustomJwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) throws IOException {
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().println(objectMapper.writeValueAsString(ApiResponse.fail(ErrorMessage.INVALID_JWT_TOKEN)));
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/security/filter/CustomJwtAuthenticationEntryPoint.java
+++ b/src/main/java/org/pingle/pingleserver/security/filter/CustomJwtAuthenticationEntryPoint.java
@@ -26,6 +26,6 @@ public class CustomJwtAuthenticationEntryPoint implements AuthenticationEntryPoi
         response.setCharacterEncoding("UTF-8");
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.getWriter().println(objectMapper.writeValueAsString(ApiResponse.fail(ErrorMessage.INVALID_JWT_TOKEN)));
+        response.getWriter().println(objectMapper.writeValueAsString(ApiResponse.fail(ErrorMessage.UNAUTHORIZED_ERROR)));
     }
 }

--- a/src/main/java/org/pingle/pingleserver/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/pingle/pingleserver/security/filter/JwtAuthenticationFilter.java
@@ -34,7 +34,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(token)) {
             Claims claims = jwtUtil.getTokenBody(token);
             Long userId = claims.get("uid", Long.class);
-            System.out.println("userId = " + userId);
             UserAuthentication authentication = new UserAuthentication(userId, null, null);
             authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
             SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/org/pingle/pingleserver/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/pingle/pingleserver/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,53 @@
+package org.pingle.pingleserver.security.filter;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.pingle.pingleserver.constant.Constants;
+import org.pingle.pingleserver.security.info.UserAuthentication;
+import org.pingle.pingleserver.utils.JwtUtil;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        final String token = getJwtFromRequest(request);
+
+        if (StringUtils.hasText(token)) {
+            Claims claims = jwtUtil.getTokenBody(token);
+            Long userId = claims.get("uid", Long.class);
+            System.out.println("userId = " + userId);
+            UserAuthentication authentication = new UserAuthentication(userId, null, null);
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader(Constants.AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(Constants.BEARER_PREFIX)) {
+            return bearerToken.substring(Constants.BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/security/info/UserAuthentication.java
+++ b/src/main/java/org/pingle/pingleserver/security/info/UserAuthentication.java
@@ -1,0 +1,13 @@
+package org.pingle.pingleserver.security.info;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class UserAuthentication extends UsernamePasswordAuthenticationToken {
+
+    public UserAuthentication(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        super(principal, credentials, authorities);
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/service/AuthService.java
+++ b/src/main/java/org/pingle/pingleserver/service/AuthService.java
@@ -3,12 +3,13 @@ package org.pingle.pingleserver.service;
 import lombok.RequiredArgsConstructor;
 import org.pingle.pingleserver.domain.User;
 import org.pingle.pingleserver.domain.enums.Provider;
+import org.pingle.pingleserver.domain.enums.URole;
 import org.pingle.pingleserver.oauth.dto.SocialInfoDto;
 import org.pingle.pingleserver.dto.request.LoginRequest;
 import org.pingle.pingleserver.dto.response.JwtTokenResponse;
 import org.pingle.pingleserver.dto.type.ErrorMessage;
 import org.pingle.pingleserver.exception.BusinessException;
-//import org.pingle.pingleserver.oauth.service.AppleLoginService;
+import org.pingle.pingleserver.oauth.service.AppleLoginService;
 import org.pingle.pingleserver.oauth.service.KakaoLoginService;
 import org.pingle.pingleserver.repository.UserRepository;
 import org.pingle.pingleserver.utils.JwtUtil;
@@ -21,22 +22,21 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
     private final JwtUtil jwtUtil;
-//    private final AppleLoginService appleLoginService;
+    private final AppleLoginService appleLoginService;
     private final KakaoLoginService kakaoLoginService;
     private final UserRepository userRepository;
 
     @Transactional
     public JwtTokenResponse login(String providerToken, LoginRequest request) {
-        SocialInfoDto socialInfo = getSocialInfo(request.provider(), providerToken);
+        SocialInfoDto socialInfo = getSocialInfo(request, providerToken);
         User user = loadOrCreateUser(request.provider(), socialInfo);
         return jwtUtil.generateTokens(user.getId(), user.getRole());
     }
 
-    private SocialInfoDto getSocialInfo(Provider provider, String providerToken){
-        if (provider.toString().equals(Provider.APPLE.toString())){
-            throw new BusinessException(ErrorMessage.INVALID_PROVIDER_ERROR);
-//            return appleLoginService.getInfo(providerToken);
-        } else if (provider.toString().equals(Provider.KAKAO.toString())){
+    private SocialInfoDto getSocialInfo(LoginRequest request, String providerToken){
+        if (request.provider().toString().equals(Provider.APPLE.toString())){
+            return appleLoginService.getInfo(providerToken, request.name());
+        } else if (request.provider().toString().equals(Provider.KAKAO.toString())){
             return kakaoLoginService.getInfo(providerToken);
         } else {
             throw new BusinessException(ErrorMessage.INVALID_PROVIDER_ERROR);

--- a/src/main/java/org/pingle/pingleserver/service/AuthService.java
+++ b/src/main/java/org/pingle/pingleserver/service/AuthService.java
@@ -30,7 +30,9 @@ public class AuthService {
     public JwtTokenResponse login(String providerToken, LoginRequest request) {
         SocialInfoDto socialInfo = getSocialInfo(request, providerToken);
         User user = loadOrCreateUser(request.provider(), socialInfo);
-        return jwtUtil.generateTokens(user.getId(), user.getRole());
+        JwtTokenResponse jwtTokenResponse = jwtUtil.generateTokens(user.getId(), user.getRole());
+        user.updateRefreshToken(jwtTokenResponse.refreshToken());
+        return jwtTokenResponse;
     }
 
     private SocialInfoDto getSocialInfo(LoginRequest request, String providerToken){

--- a/src/main/java/org/pingle/pingleserver/service/AuthService.java
+++ b/src/main/java/org/pingle/pingleserver/service/AuthService.java
@@ -1,0 +1,62 @@
+package org.pingle.pingleserver.service;
+
+import lombok.RequiredArgsConstructor;
+import org.pingle.pingleserver.domain.User;
+import org.pingle.pingleserver.domain.enums.Provider;
+import org.pingle.pingleserver.oauth.dto.SocialInfoDto;
+import org.pingle.pingleserver.dto.request.LoginRequest;
+import org.pingle.pingleserver.dto.response.JwtTokenResponse;
+import org.pingle.pingleserver.dto.type.ErrorMessage;
+import org.pingle.pingleserver.exception.BusinessException;
+//import org.pingle.pingleserver.oauth.service.AppleLoginService;
+import org.pingle.pingleserver.oauth.service.KakaoLoginService;
+import org.pingle.pingleserver.repository.UserRepository;
+import org.pingle.pingleserver.utils.JwtUtil;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final JwtUtil jwtUtil;
+//    private final AppleLoginService appleLoginService;
+    private final KakaoLoginService kakaoLoginService;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public JwtTokenResponse login(String providerToken, LoginRequest request) {
+        SocialInfoDto socialInfo = getSocialInfo(request.provider(), providerToken);
+        User user = loadOrCreateUser(request.provider(), socialInfo);
+        return jwtUtil.generateTokens(user.getId(), user.getRole());
+    }
+
+    private SocialInfoDto getSocialInfo(Provider provider, String providerToken){
+        if (provider.toString().equals(Provider.APPLE.toString())){
+            throw new BusinessException(ErrorMessage.INVALID_PROVIDER_ERROR);
+//            return appleLoginService.getInfo(providerToken);
+        } else if (provider.toString().equals(Provider.KAKAO.toString())){
+            return kakaoLoginService.getInfo(providerToken);
+        } else {
+            throw new BusinessException(ErrorMessage.INVALID_PROVIDER_ERROR);
+        }
+    }
+
+    private User loadOrCreateUser(Provider provider, SocialInfoDto socialInfo){
+        boolean isRegistered = userRepository.existsByProviderAndSerialIdAndIsDeleted(provider, socialInfo.serialId(), false);
+
+        if (!isRegistered){
+            User newUser = User.builder()
+                    .provider(provider)
+                    .serialId(socialInfo.serialId())
+                    .email(socialInfo.email())
+                    .name(socialInfo.name())
+                    .build();
+            userRepository.save(newUser);
+        }
+
+        return userRepository.findByProviderAndSerialIdAndIsDeleted(provider, socialInfo.serialId(), false)
+                .orElseThrow(() -> new BusinessException(ErrorMessage.USER_NOT_FOUND_ERROR));
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/service/AuthService.java
+++ b/src/main/java/org/pingle/pingleserver/service/AuthService.java
@@ -52,6 +52,7 @@ public class AuthService {
                     .serialId(socialInfo.serialId())
                     .email(socialInfo.email())
                     .name(socialInfo.name())
+                    .role(URole.USER)
                     .build();
             userRepository.save(newUser);
         }

--- a/src/main/java/org/pingle/pingleserver/utils/JwtUtil.java
+++ b/src/main/java/org/pingle/pingleserver/utils/JwtUtil.java
@@ -1,0 +1,77 @@
+package org.pingle.pingleserver.utils;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.pingle.pingleserver.constant.Constants;
+import org.pingle.pingleserver.domain.enums.URole;
+import org.pingle.pingleserver.dto.response.JwtTokenResponse;
+import org.pingle.pingleserver.dto.type.ErrorMessage;
+import org.pingle.pingleserver.exception.BusinessException;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtUtil implements InitializingBean {
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+    @Value("${jwt.access-token-expire-period}")
+    private Integer accessTokenExpirePeriod;
+    @Value("${jwt.refresh-token-expire-period}")
+    @Getter
+    private Integer refreshTokenExpirePeriod;
+
+    private Key key;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public JwtTokenResponse generateTokens(Long id, URole role) {
+        return JwtTokenResponse.of(
+                generateToken(id, role, accessTokenExpirePeriod),
+                generateToken(id, null, refreshTokenExpirePeriod));
+    }
+
+    public Claims getTokenBody(String token){
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (MalformedJwtException ex) {
+            throw new BusinessException(ErrorMessage.INVALID_JWT_TOKEN);
+        } catch (ExpiredJwtException ex) {
+            throw new BusinessException(ErrorMessage.EXPIRED_JWT_TOKEN);
+        } catch (UnsupportedJwtException ex) {
+            throw new BusinessException(ErrorMessage.UNSUPPORTED_JWT_TOKEN);
+        } catch (IllegalArgumentException ex) {
+            throw new BusinessException(ErrorMessage.JWT_TOKEN_IS_EMPTY);
+        }
+    }
+
+    private String generateToken(Long id, URole role, Integer expirePeriod) {
+        Claims claims = Jwts.claims();
+        claims.put(Constants.USER_ID_CLAIM_NAME, id);
+        if (role != null)
+            claims.put(Constants.USER_ROLE_CLAIM_NAME, role);
+
+        return Jwts.builder()
+                .setHeaderParam(Header.JWT_TYPE, Header.JWT_TYPE)
+                .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expirePeriod))
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,3 +15,8 @@ spring:
         show_sql: true
   config:
     import: application-secret.properties
+
+jwt:
+  secret-key: ${JWT_SECRET_KEY}
+  access-token-expire-period: 1800000 # 30분
+  refresh-token-expire-period: 1209600000 # 2주

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,8 @@
 spring:
+  mvc:
+    throw-exception-if-no-handler-found: true
+  web:
+    resources.add-mappings: false
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${DATABASE_ENDPOINT_URL}:3306/${DATABASE_NAME}?serverTimezone=UTC&characterEncoding=UTF-8
@@ -24,3 +28,4 @@ jwt:
 logging:
   level:
     org.springframework.security: DEBUG
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,4 @@
 spring:
-  mvc:
-    throw-exception-if-no-handler-found: true
-  web:
-    resources.add-mappings: false
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${DATABASE_ENDPOINT_URL}:3306/${DATABASE_NAME}?serverTimezone=UTC&characterEncoding=UTF-8

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,3 +20,7 @@ jwt:
   secret-key: ${JWT_SECRET_KEY}
   access-token-expire-period: 1800000 # 30분
   refresh-token-expire-period: 1209600000 # 2주
+
+logging:
+  level:
+    org.springframework.security: DEBUG


### PR DESCRIPTION
## Related Issue 📌
- close #6

## Description ✔️
- User 엔티티 만들었습니다.
- 애플 로그인은 아직 처리 문제가 있어서 주석 처리하고 올리지 않았습니다.
- 카카오 로그인 후 서버 토큰 반환 (Login API)
- JWT로 유저 인가 구현
- UserId 커스텀 어노테이션 제작
