### PR TITLE
[feat] 핀 관련 api 생성

### DIFF
--- a/src/main/java/org/pingle/pingleserver/controller/PinController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/PinController.java
@@ -2,8 +2,10 @@ package org.pingle.pingleserver.controller;
 
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
+import org.pingle.pingleserver.annotation.UserId;
 import org.pingle.pingleserver.domain.enums.MCategory;
 import org.pingle.pingleserver.dto.common.ApiResponse;
+import org.pingle.pingleserver.dto.reponse.MeetingResponse;
 import org.pingle.pingleserver.dto.reponse.PinResponse;
 import org.pingle.pingleserver.dto.type.SuccessMessage;
 import org.pingle.pingleserver.service.PinService;
@@ -22,5 +24,10 @@ public class PinController {
     public ApiResponse<List<PinResponse>> getPinList (@PathVariable("teamId") Long teamId, @Nullable @RequestParam("category")MCategory category) {
         return ApiResponse.success(SuccessMessage.OK, pinService.getPinListFilterByCategory(teamId, category));
 
+    }
+
+    @GetMapping("/{pinId}/meetings")
+    public ApiResponse<List<MeetingResponse>> getMeetingList(@UserId Long userId, @PathVariable("pinId") Long pinId) {
+        return ApiResponse.success(SuccessMessage.OK, pinService.getMeetingDetailList(userId, pinId));
     }
 }

--- a/src/main/java/org/pingle/pingleserver/controller/PinController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/PinController.java
@@ -1,0 +1,26 @@
+package org.pingle.pingleserver.controller;
+
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.pingle.pingleserver.domain.enums.MCategory;
+import org.pingle.pingleserver.dto.common.ApiResponse;
+import org.pingle.pingleserver.dto.reponse.PinResponse;
+import org.pingle.pingleserver.dto.type.SuccessMessage;
+import org.pingle.pingleserver.service.PinService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/teams/{teamId}/pins")
+@RequiredArgsConstructor
+public class PinController {
+
+    private final PinService pinService;
+
+    @GetMapping
+    public ApiResponse<List<PinResponse>> getPinList (@PathVariable("teamId") Long teamId, @Nullable @RequestParam("category")MCategory category) {
+        return ApiResponse.success(SuccessMessage.OK, pinService.getPinListFilterByCategory(teamId, category));
+
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/domain/Pin.java
+++ b/src/main/java/org/pingle/pingleserver/domain/Pin.java
@@ -5,6 +5,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -16,6 +18,9 @@ public class Pin extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Team team;
+
+    @OneToMany(mappedBy = "pin")
+    private List<Meeting> meetingList;
 
     @Embedded
     private Point point;

--- a/src/main/java/org/pingle/pingleserver/domain/enums/MCategory.java
+++ b/src/main/java/org/pingle/pingleserver/domain/enums/MCategory.java
@@ -1,11 +1,10 @@
 package org.pingle.pingleserver.domain.enums;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor
 public enum MCategory {
     PLAY("play"), STUDY("study"), MULTI("multi"), OTHERS("others");
 

--- a/src/main/java/org/pingle/pingleserver/dto/reponse/MeetingResponse.java
+++ b/src/main/java/org/pingle/pingleserver/dto/reponse/MeetingResponse.java
@@ -1,0 +1,10 @@
+package org.pingle.pingleserver.dto.reponse;
+
+import lombok.Builder;
+import org.pingle.pingleserver.domain.enums.MCategory;
+
+@Builder
+public record MeetingResponse(Long id, MCategory category, String name, String ownerName,
+                              String location, String date, String startAt, String endAt, int maxParticipants,
+                              int curParticipants, boolean isParticipating, String chatLink) {
+}

--- a/src/main/java/org/pingle/pingleserver/dto/reponse/PinResponse.java
+++ b/src/main/java/org/pingle/pingleserver/dto/reponse/PinResponse.java
@@ -1,0 +1,27 @@
+package org.pingle.pingleserver.dto.reponse;
+
+import org.pingle.pingleserver.domain.Meeting;
+import org.pingle.pingleserver.domain.Pin;
+import org.pingle.pingleserver.domain.enums.MCategory;
+
+import java.util.Comparator;
+import java.util.List;
+
+public record PinResponse(Long id, Double x, Double y, MCategory category, int meetingCount) {
+    public static PinResponse of(Pin pin) {
+        return new PinResponse(pin.getId(),pin.getPoint().getX(), pin.getPoint().getY(),
+                getMostRecentMeetingCategoryOfPin(pin), getMeetingCount(pin));
+
+    }
+    private static MCategory getMostRecentMeetingCategoryOfPin (Pin pin) {
+        Comparator<Meeting> comparator = Comparator.comparing(Meeting::getStartAt);
+        List<Meeting> meetingList = pin.getMeetingList();
+        meetingList.sort(comparator);
+        return meetingList.get(0).getCategory();
+    }
+
+    private static int getMeetingCount(Pin pin) {
+        return pin.getMeetingList().size();
+    }
+
+}

--- a/src/main/java/org/pingle/pingleserver/dto/type/ErrorMessage.java
+++ b/src/main/java/org/pingle/pingleserver/dto/type/ErrorMessage.java
@@ -28,6 +28,7 @@ public enum ErrorMessage {
     UNAUTHORIZED_ERROR(HttpStatus.UNAUTHORIZED, "토큰이 제공되지 않았거나 유효하지 않습니다."),
     NO_SUCH_USER(HttpStatus.UNAUTHORIZED, "존재하지 않는 사용자입니다."),
     // Not Found Error 404
+    NOT_FOUND_RESOURCE(HttpStatus.NOT_FOUND, "해당 리소스가 존재하지 않습니다."),
     USER_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND, "존재하지 않는 API입니다."),
     // Method Not Allowed Error 405

--- a/src/main/java/org/pingle/pingleserver/repository/PinRepository.java
+++ b/src/main/java/org/pingle/pingleserver/repository/PinRepository.java
@@ -1,7 +1,11 @@
 package org.pingle.pingleserver.repository;
 
 import org.pingle.pingleserver.domain.Pin;
+import org.pingle.pingleserver.domain.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PinRepository extends JpaRepository<Pin, Long> {
+ List<Pin> findAllByTeam(Team team);
 }

--- a/src/main/java/org/pingle/pingleserver/repository/UserMeetingRepository.java
+++ b/src/main/java/org/pingle/pingleserver/repository/UserMeetingRepository.java
@@ -1,7 +1,15 @@
 package org.pingle.pingleserver.repository;
 
+import org.pingle.pingleserver.domain.Meeting;
 import org.pingle.pingleserver.domain.UserMeeting;
+import org.pingle.pingleserver.domain.enums.MRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface UserMeetingRepository extends JpaRepository<UserMeeting, Long> {
+    Optional<UserMeeting> findByMeetingAndMeetingRole(Meeting meeting, MRole role);
+    boolean existsByUserIdAndMeeting(Long userId, Meeting meeting);
+    List<UserMeeting> findAllByMeeting(Meeting meeting);
 }

--- a/src/main/java/org/pingle/pingleserver/repository/UserMeetingRepository.java
+++ b/src/main/java/org/pingle/pingleserver/repository/UserMeetingRepository.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 public interface UserMeetingRepository extends JpaRepository<UserMeeting, Long> {
     Optional<UserMeeting> findByMeetingAndMeetingRole(Meeting meeting, MRole role);
     List<UserMeeting> findAllByMeeting(Meeting meeting);
-    List<UserMeeting> findAllByMeeting(Meeting meeting);
     boolean existsByUserIdAndMeeting(Long userId, Meeting meeting);
     Optional<UserMeeting> findByUserIdAndMeetingId(Long userId, Long MeetingId);
 }

--- a/src/main/java/org/pingle/pingleserver/service/PinService.java
+++ b/src/main/java/org/pingle/pingleserver/service/PinService.java
@@ -112,6 +112,7 @@ public class PinService {
     private String getTimeFromDateTime(LocalDateTime localDateTime) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
         return localDateTime.format(formatter);
+    }
 
     private boolean exist(Point point) {
         return pinRepository.existsByPoint(point);

--- a/src/main/java/org/pingle/pingleserver/service/PinService.java
+++ b/src/main/java/org/pingle/pingleserver/service/PinService.java
@@ -41,15 +41,6 @@ public class PinService {
         return pinList.stream().filter(pin -> checkMeetingsCategoryOfPin(pin, category)).map(PinResponse::of).toList();
     }
 
-    private boolean checkMeetingsCategoryOfPin(Pin pin, MCategory category) {
-        List<Meeting> meetingList = pin.getMeetingList();
-        for(Meeting meeting : meetingList) {
-            if(meeting.getCategory().getValue().equals(category.getValue()))
-                return true;
-        }
-        return false;
-    }
-
     public List<MeetingResponse> getMeetingDetailList(Long userId, Long pinId) {
         Pin pin = pinRepository.findById(pinId).orElseThrow(() -> new BusinessException(ErrorMessage.NOT_FOUND_RESOURCE));
         Comparator<Meeting> comparator = Comparator.comparing(Meeting::getStartAt);
@@ -73,6 +64,15 @@ public class PinService {
                                             .build());
         }
         return responseList;
+    }
+
+    private boolean checkMeetingsCategoryOfPin(Pin pin, MCategory category) {
+        List<Meeting> meetingList = pin.getMeetingList();
+        for(Meeting meeting : meetingList) {
+            if(meeting.getCategory().getValue().equals(category.getValue()))
+                return true;
+        }
+        return false;
     }
 
     private String getOwnerName(Meeting meeting) {

--- a/src/main/java/org/pingle/pingleserver/service/PinService.java
+++ b/src/main/java/org/pingle/pingleserver/service/PinService.java
@@ -25,7 +25,7 @@ public class PinService {
 
     public List<PinResponse> getPinListFilterByCategory(Long teamId, MCategory category) {
         Team team = teamRepository.findById(teamId).orElseThrow(() -> new BusinessException(ErrorMessage.NOT_FOUND_RESOURCE));
-        List<Pin> pinList = pinRepository.findAllByTeam(team);//현재 약속중 category갖는 핀만 갖고 있음
+        List<Pin> pinList = pinRepository.findAllByTeam(team);
         if(category == null) return pinList.stream().map(PinResponse::of).toList();
         return pinList.stream().filter(pin -> checkMeetingsCategoryOfPin(pin, category)).map(PinResponse::of).toList();
     }

--- a/src/main/java/org/pingle/pingleserver/service/PinService.java
+++ b/src/main/java/org/pingle/pingleserver/service/PinService.java
@@ -1,11 +1,41 @@
 package org.pingle.pingleserver.service;
 
 import lombok.RequiredArgsConstructor;
+import org.pingle.pingleserver.domain.Meeting;
+import org.pingle.pingleserver.domain.Pin;
+import org.pingle.pingleserver.domain.Team;
+import org.pingle.pingleserver.domain.enums.MCategory;
+import org.pingle.pingleserver.dto.reponse.PinResponse;
+import org.pingle.pingleserver.dto.type.ErrorMessage;
+import org.pingle.pingleserver.exception.BusinessException;
+import org.pingle.pingleserver.repository.PinRepository;
+import org.pingle.pingleserver.repository.TeamRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class PinService {
+
+    private final PinRepository pinRepository;
+    private final TeamRepository teamRepository;
+
+    public List<PinResponse> getPinListFilterByCategory(Long teamId, MCategory category) {
+        Team team = teamRepository.findById(teamId).orElseThrow(() -> new BusinessException(ErrorMessage.NOT_FOUND_RESOURCE));
+        List<Pin> pinList = pinRepository.findAllByTeam(team);//현재 약속중 category갖는 핀만 갖고 있음
+        if(category == null) return pinList.stream().map(PinResponse::of).toList();
+        return pinList.stream().filter(pin -> checkMeetingsCategoryOfPin(pin, category)).map(PinResponse::of).toList();
+    }
+
+    private boolean checkMeetingsCategoryOfPin(Pin pin, MCategory category) {
+        List<Meeting> meetingList = pin.getMeetingList();
+        for(Meeting meeting : meetingList) {
+            if(meeting.getCategory().getValue().equals(category.getValue()))
+                return true;
+        }
+        return false;
+    }
 }

--- a/src/main/java/org/pingle/pingleserver/service/PinService.java
+++ b/src/main/java/org/pingle/pingleserver/service/PinService.java
@@ -1,20 +1,30 @@
 package org.pingle.pingleserver.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.pingle.pingleserver.domain.Meeting;
 import org.pingle.pingleserver.domain.Pin;
 import org.pingle.pingleserver.domain.Team;
+import org.pingle.pingleserver.domain.UserMeeting;
 import org.pingle.pingleserver.domain.enums.MCategory;
+import org.pingle.pingleserver.domain.enums.MRole;
+import org.pingle.pingleserver.dto.reponse.MeetingResponse;
 import org.pingle.pingleserver.dto.reponse.PinResponse;
 import org.pingle.pingleserver.dto.type.ErrorMessage;
 import org.pingle.pingleserver.exception.BusinessException;
 import org.pingle.pingleserver.repository.PinRepository;
 import org.pingle.pingleserver.repository.TeamRepository;
+import org.pingle.pingleserver.repository.UserMeetingRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -22,6 +32,7 @@ public class PinService {
 
     private final PinRepository pinRepository;
     private final TeamRepository teamRepository;
+    private final UserMeetingRepository userMeetingRepository;
 
     public List<PinResponse> getPinListFilterByCategory(Long teamId, MCategory category) {
         Team team = teamRepository.findById(teamId).orElseThrow(() -> new BusinessException(ErrorMessage.NOT_FOUND_RESOURCE));
@@ -37,5 +48,52 @@ public class PinService {
                 return true;
         }
         return false;
+    }
+
+    public List<MeetingResponse> getMeetingDetailList(Long userId, Long pinId) {
+        Pin pin = pinRepository.findById(pinId).orElseThrow(() -> new BusinessException(ErrorMessage.NOT_FOUND_RESOURCE));
+        Comparator<Meeting> comparator = Comparator.comparing(Meeting::getStartAt);
+        List<Meeting> meetingList = pin.getMeetingList();
+        meetingList.sort(comparator);
+        List<MeetingResponse> responseList = new ArrayList<>();
+        for(Meeting meeting : meetingList) {
+            responseList.add(MeetingResponse.builder()
+                    .id(meeting.getId())
+                            .category(meeting.getCategory())
+                            .name(meeting.getName())
+                            .ownerName(getOwnerName(meeting))//만든사람
+                            .location(pin.getName())
+                            .date(getDateFromDateTime(meeting.getStartAt()))//meeting start 날짜 parsing
+                            .startAt(getTimeFromDateTime(meeting.getStartAt()))//start 시간 parsing
+                            .endAt(getTimeFromDateTime(meeting.getEndAt()))//end 시간 parsing
+                            .maxParticipants(meeting.getMaxParticipants())
+                            .curParticipants(getCurParticipants(meeting))
+                            .isParticipating(isParticipating(userId, meeting))
+                            .chatLink(meeting.getChatLink())
+                                            .build());
+        }
+        return responseList;
+    }
+
+    private String getOwnerName(Meeting meeting) {
+        UserMeeting userMeeting = userMeetingRepository.findByMeetingAndMeetingRole(meeting, MRole.OWNER).orElseThrow(() ->new BusinessException(ErrorMessage.NOT_FOUND_RESOURCE ));
+        return userMeeting.getUser().getName();
+    }
+
+    private int getCurParticipants(Meeting meeting) {
+        return userMeetingRepository.findAllByMeeting(meeting).size();
+    }
+
+    private boolean isParticipating(Long userId, Meeting meeting) {
+        return userMeetingRepository.existsByUserIdAndMeeting(userId, meeting);
+    }
+
+    private String getDateFromDateTime(LocalDateTime localDateTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        return localDateTime.format(formatter);
+    }
+    private String getTimeFromDateTime(LocalDateTime localDateTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
+        return localDateTime.format(formatter);
     }
 }


### PR DESCRIPTION
## Related Issue 📌
- close #26 

## Description ✔️
- 핀리스트 반환 api
- 번개리스트 반환 api

## To Reviewers
현재 번개 리스트를 사용하는 1차 이후 스프린트 뷰가 정해지지 않아서 현재 카테고리 선택시
복수개의 번개를 보유한 핀은 가장 최근에 일어날 번개의 카테고리를 반환하도록 했습니다.
(ex. 하나의 핀에 PLAY PLAY MULTI 순으로 번개가 예정되어 있다면 query parameter가 MULTI일때 해당핀의 category는 PLAY로 response가 반환됩니다.)