### PR TITLE
[feat] 로그인한 유저 정보 불러오기 API에 단체 추가

### DIFF
--- a/src/main/java/org/pingle/pingleserver/domain/User.java
+++ b/src/main/java/org/pingle/pingleserver/domain/User.java
@@ -9,6 +9,7 @@ import org.pingle.pingleserver.domain.enums.Provider;
 import org.pingle.pingleserver.domain.enums.URole;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -40,6 +41,9 @@ public class User {
     private boolean isDeleted = false;
 
     private LocalDateTime deletedAt;
+
+    @OneToMany(mappedBy = "user")
+    private List<UserTeam> userTeams;
 
     @Builder
     public User(String serialId, String name, String email, Provider provider, URole role, String refreshToken) {

--- a/src/main/java/org/pingle/pingleserver/dto/response/SimpleGroupInfo.java
+++ b/src/main/java/org/pingle/pingleserver/dto/response/SimpleGroupInfo.java
@@ -1,0 +1,9 @@
+package org.pingle.pingleserver.dto.response;
+
+import org.pingle.pingleserver.domain.UserTeam;
+
+public record SimpleGroupInfo(Long id, String name) {
+    public static SimpleGroupInfo of(UserTeam userTeam) {
+        return new SimpleGroupInfo(userTeam.getTeam().getId(), userTeam.getTeam().getName());
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/dto/response/UserInfoResponse.java
+++ b/src/main/java/org/pingle/pingleserver/dto/response/UserInfoResponse.java
@@ -1,10 +1,21 @@
 package org.pingle.pingleserver.dto.response;
 
 import org.pingle.pingleserver.domain.User;
+import org.pingle.pingleserver.domain.UserTeam;
 import org.pingle.pingleserver.domain.enums.Provider;
 
-public record UserInfoResponse(Long id, String name, String email, Provider provider){
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record UserInfoResponse(Long id, String name, String email, Provider provider, List<SimpleGroupInfo> groups){
     public static UserInfoResponse of(User user){
-        return new UserInfoResponse(user.getId(), user.getName(), user.getEmail(), user.getProvider());
+        return new UserInfoResponse(user.getId(), user.getName(),
+                user.getEmail(), user.getProvider(), getSimpleGroupsInfo(user.getUserTeams()));
+    }
+
+    private static List<SimpleGroupInfo> getSimpleGroupsInfo(List<UserTeam> userTeams){
+        return userTeams.stream()
+                .map(SimpleGroupInfo::of)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## Related Issue 📌
- close #39

## Description ✔️
- 그룹에 가입했는지, 그룹 정보를 포함하게 변경
