### PR TITLE
[feat] http 상태코드 일치, Request 헤더명 변경

### DIFF
--- a/src/main/java/org/pingle/pingleserver/constant/Constants.java
+++ b/src/main/java/org/pingle/pingleserver/constant/Constants.java
@@ -1,9 +1,12 @@
 package org.pingle.pingleserver.constant;
 
 public class Constants {
-    public static String USER_ID_CLAIM_NAME = "uid";
-    public static String USER_ROLE_CLAIM_NAME = "rol";
-    public static String BEARER_PREFIX = "Bearer ";
-    public static String AUTHORIZATION_HEADER = "Authorization";
+    public static final String USER_ID_CLAIM_NAME = "uid";
+    public static final String USER_ROLE_CLAIM_NAME = "rol";
+    public static final String BEARER_PREFIX = "Bearer ";
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String GROUP_ID = "X-Group-Id";
+    public static final String PROVIDER_TOKEN = "X-Provider-Token";
+
 
 }

--- a/src/main/java/org/pingle/pingleserver/controller/AuthController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/AuthController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.pingle.pingleserver.annotation.UserId;
+import org.pingle.pingleserver.constant.Constants;
 import org.pingle.pingleserver.dto.common.ApiResponse;
 import org.pingle.pingleserver.dto.request.LoginRequest;
 import org.pingle.pingleserver.dto.request.ReissueRequest;
@@ -21,7 +22,7 @@ public class AuthController {
 
     @PostMapping("/login")
     public ApiResponse<JwtTokenResponse> login(
-            @NotNull @RequestHeader("Provider-Token") String providerToken,
+            @NotNull @RequestHeader(Constants.PROVIDER_TOKEN) String providerToken,
             @Valid @RequestBody LoginRequest request){
         return ApiResponse.success(SuccessMessage.OK, authService.login(providerToken, request));
     }

--- a/src/main/java/org/pingle/pingleserver/controller/MeetingController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/MeetingController.java
@@ -5,6 +5,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.pingle.pingleserver.annotation.UserId;
 import org.pingle.pingleserver.annotation.GUserId;
+import org.pingle.pingleserver.constant.Constants;
 import org.pingle.pingleserver.domain.Meeting;
 import org.pingle.pingleserver.domain.Pin;
 import org.pingle.pingleserver.dto.common.ApiResponse;
@@ -21,14 +22,13 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class MeetingController {
 
-    private static final String GROUP_ID = "X-Group-Id";
     private final MeetingService meetingService;
     private final UserMeetingService userMeetingService;
     private final PinService pinService;
 
     @PostMapping
     public ApiResponse<?> createMeeting(@Valid @RequestBody MeetingRequest request, @GUserId Long userId,
-                                        @RequestHeader(GROUP_ID) Long groupId) {
+                                        @RequestHeader(Constants.GROUP_ID) Long groupId) {
         Pin pin = pinService.verifyAndReturnPin(request, groupId);//핀 없으면 핀 생성 후 반환, 있다면 핀 생성
         Meeting meeting = meetingService.createMeeting(request, pin);//번개 생성
         Long userMeetingId = userMeetingService.addOwnerToMeeting(userId, meeting);

--- a/src/main/java/org/pingle/pingleserver/interceptor/post/PingleResponseAdvice.java
+++ b/src/main/java/org/pingle/pingleserver/interceptor/post/PingleResponseAdvice.java
@@ -1,0 +1,27 @@
+package org.pingle.pingleserver.interceptor.post;
+
+import org.pingle.pingleserver.dto.common.ApiResponse;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice(basePackages="org.pingle.pingleserver")
+public class PingleResponseAdvice implements ResponseBodyAdvice {
+    @Override
+    public boolean supports(MethodParameter returnType, Class converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType, Class selectedConverterType, ServerHttpRequest request, ServerHttpResponse response) {
+        if (returnType.getParameterType() == ApiResponse.class) {
+            HttpStatus status = HttpStatus.valueOf(((ApiResponse<?>) body).getCode());
+            response.setStatusCode(status);
+        }
+        return body;
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/interceptor/pre/GUserIdArgumentResolver.java
+++ b/src/main/java/org/pingle/pingleserver/interceptor/pre/GUserIdArgumentResolver.java
@@ -2,6 +2,7 @@ package org.pingle.pingleserver.interceptor.pre;
 
 import lombok.RequiredArgsConstructor;
 import org.pingle.pingleserver.annotation.GUserId;
+import org.pingle.pingleserver.constant.Constants;
 import org.pingle.pingleserver.dto.type.ErrorMessage;
 import org.pingle.pingleserver.exception.CustomException;
 import org.pingle.pingleserver.service.UserMeetingService;
@@ -36,9 +37,9 @@ public class GUserIdArgumentResolver implements HandlerMethodArgumentResolver {
             throw new CustomException(ErrorMessage.EMPTY_PRINCIPAL);
         }
 
-        if (webRequest.getHeader("Group-Id") == null)
+        if (webRequest.getHeader(Constants.GROUP_ID) == null)
             throw new CustomException(ErrorMessage.INVALID_HEADER_ERROR);
-        Long groupId = Long.valueOf(webRequest.getHeader("Group-Id"));
+        Long groupId = Long.valueOf(webRequest.getHeader(Constants.GROUP_ID));
 
         userMeetingService.verifyUser(getIdFromPrincipal(principal), groupId);
 


### PR DESCRIPTION
## Related Issue 📌
- close #46 

## Description ✔️
- http 상태코드와 http body의 상태코드 일치시키는 작업
- 커스텀 헤더명 앞에 X- 추가

## To Reviewers
