### PR TITLE
[fix] refreshToken 설계 오류

### DIFF
--- a/src/main/java/org/pingle/pingleserver/controller/AuthController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/AuthController.java
@@ -7,7 +7,6 @@ import org.pingle.pingleserver.annotation.UserId;
 import org.pingle.pingleserver.constant.Constants;
 import org.pingle.pingleserver.dto.common.ApiResponse;
 import org.pingle.pingleserver.dto.request.LoginRequest;
-import org.pingle.pingleserver.dto.request.ReissueRequest;
 import org.pingle.pingleserver.dto.response.JwtTokenResponse;
 import org.pingle.pingleserver.dto.type.SuccessMessage;
 import org.pingle.pingleserver.service.AuthService;
@@ -29,8 +28,8 @@ public class AuthController {
 
     @PostMapping("/reissue")
     public ApiResponse<JwtTokenResponse> reissue(
-            @Valid @RequestBody ReissueRequest request){
-        return ApiResponse.success(SuccessMessage.OK, authService.reissue(request));
+            @NotNull @RequestHeader(Constants.AUTHORIZATION_HEADER) String refreshToken){
+        return ApiResponse.success(SuccessMessage.OK, authService.reissue(refreshToken));
     }
 
     @PostMapping("/logout")

--- a/src/main/java/org/pingle/pingleserver/controller/TestController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/TestController.java
@@ -6,11 +6,11 @@ import org.pingle.pingleserver.annotation.UserId;
 import org.pingle.pingleserver.domain.User;
 import org.pingle.pingleserver.dto.response.JwtTokenResponse;
 import org.pingle.pingleserver.exception.CustomException;
-import org.pingle.pingleserver.dto.response.JwtTokenResponse;
 import org.pingle.pingleserver.dto.type.ErrorMessage;
 import org.pingle.pingleserver.repository.UserRepository;
 import org.pingle.pingleserver.utils.JwtUtil;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,6 +25,7 @@ public class TestController {
     private final JwtUtil jwtUtil;
     private final UserRepository userRepository;
 
+    @Transactional
     @GetMapping("/token/{userId}")
     public JwtTokenResponse testToken(@PathVariable Long userId) {
         User user = userRepository.findById(userId)

--- a/src/main/java/org/pingle/pingleserver/dto/request/ReissueRequest.java
+++ b/src/main/java/org/pingle/pingleserver/dto/request/ReissueRequest.java
@@ -1,6 +1,0 @@
-package org.pingle.pingleserver.dto.request;
-
-import jakarta.validation.constraints.NotNull;
-
-public record ReissueRequest(@NotNull String refreshToken) {
-}

--- a/src/main/java/org/pingle/pingleserver/dto/type/ErrorMessage.java
+++ b/src/main/java/org/pingle/pingleserver/dto/type/ErrorMessage.java
@@ -13,10 +13,11 @@ public enum ErrorMessage {
     EXPIRED_APPLE_IDENTITY_TOKEN(HttpStatus.BAD_REQUEST, "만료된 Apple Identity Token입니다."),
     CREATE_PUBLIC_KEY_EXCEPTION(HttpStatus.BAD_REQUEST, "Apple Public verify에 실패했습니다."),
     // JWT Error
-    INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다."),
-    EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
-    UNSUPPORTED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 JWT 토큰입니다."),
-    JWT_TOKEN_IS_EMPTY(HttpStatus.UNAUTHORIZED, "JWT 토큰이 비어있습니다."),
+    INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    UNSUPPORTED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 토큰입니다."),
+    JWT_TOKEN_IS_EMPTY(HttpStatus.UNAUTHORIZED, "토큰이 비어있습니다."),
+    INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰 타입입니다."),
     // Invalid Argument Error 400
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     ALREADY_REGISTERED_USER(HttpStatus.BAD_REQUEST, "이미 가입된 사용자입니다."),

--- a/src/main/java/org/pingle/pingleserver/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/pingle/pingleserver/security/filter/JwtAuthenticationFilter.java
@@ -9,6 +9,8 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.pingle.pingleserver.constant.Constants;
+import org.pingle.pingleserver.dto.type.ErrorMessage;
+import org.pingle.pingleserver.exception.CustomException;
 import org.pingle.pingleserver.security.info.UserAuthentication;
 import org.pingle.pingleserver.utils.JwtUtil;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -33,7 +35,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (StringUtils.hasText(token)) {
             Claims claims = jwtUtil.getTokenBody(token);
-            Long userId = claims.get("uid", Long.class);
+            Long userId = claims.get(Constants.USER_ID_CLAIM_NAME, Long.class);
+            if (claims.get(Constants.USER_ROLE_CLAIM_NAME, String.class) == null) {
+                if (!request.getRequestURI().equals("/v1/auth/reissue"))
+                    throw new CustomException(ErrorMessage.INVALID_TOKEN_TYPE);
+            }
             UserAuthentication authentication = new UserAuthentication(userId, null, null);
             authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
             SecurityContextHolder.getContext().setAuthentication(authentication);


### PR DESCRIPTION
## Related Issue 📌
- close #51

## Description ✔️
- refreshToken과 accessToken이 같은 역할을 할 수 있게 설계되어서 수정을 했습니다.
- refreshToken의 경우 role이 없고 accessToken의 경우 role이 있습니다.
- JwtAuthenticationFilter에서 받은 토큰에 role이 없는 경우 오류를 일으킵니다 -> CustomJwtAuthenticationEnntryPoint의 response로 연결됩니다.
- whitlelist에 `v1/auth/reissue` 를 경로로 추가하였지만 그것과 별개로 JwtAuthenticationFilter를 무조건 통과하게 되고 이때 role이 없기 때문에 오류가 일어나게 되므로 requestUri가 `v1/auth/reissue`일 경우 에러가 일어나지 않도록 분기처리를 했습니다.