### PR TITLE
[fix] get meetings details api 수정

### DIFF
--- a/src/main/java/org/pingle/pingleserver/dto/reponse/MeetingResponse.java
+++ b/src/main/java/org/pingle/pingleserver/dto/reponse/MeetingResponse.java
@@ -6,5 +6,5 @@ import org.pingle.pingleserver.domain.enums.MCategory;
 @Builder
 public record MeetingResponse(Long id, MCategory category, String name, String ownerName,
                               String location, String date, String startAt, String endAt, int maxParticipants,
-                              int curParticipants, boolean isParticipating, String chatLink) {
+                              int curParticipants, boolean isParticipating, String chatLink, boolean isOwner) {
 }

--- a/src/main/java/org/pingle/pingleserver/repository/UserMeetingRepository.java
+++ b/src/main/java/org/pingle/pingleserver/repository/UserMeetingRepository.java
@@ -7,13 +7,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-
-import java.util.List;
-import java.util.Optional;
-
 public interface UserMeetingRepository extends JpaRepository<UserMeeting, Long> {
     Optional<UserMeeting> findByMeetingAndMeetingRole(Meeting meeting, MRole role);
     List<UserMeeting> findAllByMeeting(Meeting meeting);
     boolean existsByUserIdAndMeeting(Long userId, Meeting meeting);
     Optional<UserMeeting> findByUserIdAndMeetingId(Long userId, Long MeetingId);
+    boolean existsByUserIdAndMeetingIdAndMeetingRole(Long userId, Long meetingId, MRole role);
 }

--- a/src/main/java/org/pingle/pingleserver/service/PinService.java
+++ b/src/main/java/org/pingle/pingleserver/service/PinService.java
@@ -66,6 +66,7 @@ public class PinService {
                         .curParticipants(getCurParticipants(meeting))
                         .isParticipating(isParticipating(userId, meeting))
                         .chatLink(meeting.getChatLink())
+                        .isOwner(isOwner(userId, meeting.getId()))
                         .build());
             }
             return responseList;
@@ -137,6 +138,12 @@ public class PinService {
     private String getTimeFromDateTime(LocalDateTime localDateTime) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
         return localDateTime.format(formatter);
+    }
+
+    private boolean isOwner(Long userId, Long meetingId) {
+        if(userMeetingRepository.existsByUserIdAndMeetingIdAndMeetingRole(userId, meetingId, MRole.OWNER))
+            return true;
+        return false;
     }
 
     private boolean exist(Point point) {

--- a/src/main/java/org/pingle/pingleserver/service/UserMeetingService.java
+++ b/src/main/java/org/pingle/pingleserver/service/UserMeetingService.java
@@ -57,6 +57,8 @@ public class UserMeetingService {
     public Long cancelMeeting(Long userId, Long meetingId) {
         UserMeeting userMeeting = userMeetingRepository.findByUserIdAndMeetingId(userId, meetingId)
                 .orElseThrow(() -> new CustomException(ErrorMessage.RESOURCE_NOT_FOUND));
+        if(userMeetingRepository.existsByUserIdAndMeetingIdAndMeetingRole(userId, meetingId, MRole.OWNER))
+            throw new CustomException(ErrorMessage.BAD_REQUEST);
         userMeetingRepository.delete(userMeeting);
         return userMeeting.getId();
     }


### PR DESCRIPTION
## Related Issue 📌
- close #61 

## Description ✔️
- meetings details response를 변경하여 클라이언트에서 isOwner를 통해 번개 취소 분기 처리할 수 있도록 처리
- cancel meeting api에 Owner가 참여취소 요청을 보내면 400 bad request custom eror 발생

## To Reviewers
