### PR TITLE
[fix] get meetings details api 수정

### DIFF
--- a/src/main/java/org/pingle/pingleserver/service/PinService.java
+++ b/src/main/java/org/pingle/pingleserver/service/PinService.java
@@ -87,6 +87,7 @@ public class PinService {
                         .curParticipants(getCurParticipants(meeting))
                         .isParticipating(isParticipating(userId, meeting))
                         .chatLink(meeting.getChatLink())
+                        .isOwner(isOwner(userId, meeting.getId()))
                         .build());
             }
         }


### PR DESCRIPTION
## Related Issue 📌
- close #61 

## Description ✔️
- 수정 pr입니다.
- get meetings details api에 category가 들어왔을 때도 isOwner를 반환하도록 하였습니다.

## To Reviewers
