### PR TITLE
[fix] 핀 생성 오류 해결

### DIFF
--- a/src/main/java/org/pingle/pingleserver/repository/PinRepository.java
+++ b/src/main/java/org/pingle/pingleserver/repository/PinRepository.java
@@ -9,6 +9,6 @@ import java.util.List;
 
 public interface PinRepository extends JpaRepository<Pin, Long> {
     List<Pin> findAllByTeam(Team team);
-    boolean existsByPoint(Point point);
-    Pin findByPoint(Point point);
+    boolean existsByPointAndTeam(Point point, Team team);
+    Pin findByPointAndTeam(Point point, Team team);
 }

--- a/src/main/java/org/pingle/pingleserver/service/PinService.java
+++ b/src/main/java/org/pingle/pingleserver/service/PinService.java
@@ -97,7 +97,7 @@ public class PinService {
     @Transactional
     public Pin verifyAndReturnPin(MeetingRequest request, Long groupId) {
         Team team = teamRepository.findByIdOrThrow(groupId);
-        if(!exist(new Point(request.x(), request.y()))) {
+        if(!pinRepository.existsByPointAndTeam(new Point(request.x(), request.y()), team)) {
              return pinRepository.save(Pin.builder()
                     .address(new Address(request.roadAddress(), request.address()))
                     .name(request.location())
@@ -105,7 +105,7 @@ public class PinService {
                     .team(team)
                     .build());
         }
-        return pinRepository.findByPoint(new Point(request.x(), request.y()));
+        return pinRepository.findByPointAndTeam(new Point(request.x(), request.y()), team);
     }
   
     private boolean checkMeetingsCategoryOfPin(Pin pin, MCategory category) {

--- a/src/main/java/org/pingle/pingleserver/service/PinService.java
+++ b/src/main/java/org/pingle/pingleserver/service/PinService.java
@@ -141,12 +141,6 @@ public class PinService {
     }
 
     private boolean isOwner(Long userId, Long meetingId) {
-        if(userMeetingRepository.existsByUserIdAndMeetingIdAndMeetingRole(userId, meetingId, MRole.OWNER))
-            return true;
-        return false;
-    }
-
-    private boolean exist(Point point) {
-        return pinRepository.existsByPoint(point);
+        return userMeetingRepository.existsByUserIdAndMeetingIdAndMeetingRole(userId, meetingId, MRole.OWNER);
     }
 }


### PR DESCRIPTION
## Related Issue 📌
- close #71 

## Description ✔️
- 팀마다 핀이 다른데 핀이 있는지 검증하는 로직에 팀은 함께 검사하지 않음
- 그 결과 팀1에서 홍익대를 먼저 만든 후 팀2에서 홍익대에서 미팅을 열려고 시도할 경우 1번 팀의 핀으로 연결이 되는 오류 발생
- 팀 검증 추가해서 해경(AndTeam)
- 그 외 메소드 축약