### PR TITLE
[fix] get meetings api, get pins api 수정

### DIFF
--- a/src/main/java/org/pingle/pingleserver/dto/reponse/PinResponse.java
+++ b/src/main/java/org/pingle/pingleserver/dto/reponse/PinResponse.java
@@ -4,7 +4,9 @@ import org.pingle.pingleserver.domain.Meeting;
 import org.pingle.pingleserver.domain.Pin;
 import org.pingle.pingleserver.domain.enums.MCategory;
 
+import java.time.LocalDateTime;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 
 public record PinResponse(Long id, Double x, Double y, MCategory category, int meetingCount) {
@@ -19,18 +21,37 @@ public record PinResponse(Long id, Double x, Double y, MCategory category, int m
 
     }
     private static MCategory getMostRecentMeetingCategoryOfPin (Pin pin) {
-        Comparator<Meeting> comparator = Comparator.comparing(Meeting::getStartAt);
         List<Meeting> meetingList = pin.getMeetingList();
-        meetingList.sort(comparator);
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        meetingList.removeIf(meeting -> meeting.getStartAt() != null && meeting.getStartAt().isBefore(currentDateTime));
+        meetingList.sort(Comparator.comparing(Meeting::getStartAt));
+
         return meetingList.get(0).getCategory();
     }
 
     private static int getMeetingCount(Pin pin) {
-        return pin.getMeetingList().size();
+        List<Meeting> meetingList = pin.getMeetingList();
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        Iterator<Meeting> iterator = meetingList.iterator();
+        while (iterator.hasNext()) {
+            Meeting meeting = iterator.next();
+            if (meeting.getStartAt() != null && meeting.getStartAt().isBefore(currentDateTime)) {
+                iterator.remove();
+            }
+        }
+        return meetingList.size();
     }
     private static int getMeetingCountWithFilter(Pin pin, MCategory category) {
         int count = 0;
         List<Meeting> meetings = pin.getMeetingList();
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        Iterator<Meeting> iterator = meetings.iterator();
+        while (iterator.hasNext()) {
+            Meeting meeting = iterator.next();
+            if (meeting.getStartAt() != null && meeting.getStartAt().isBefore(currentDateTime)) {//핀의 미팅 중에서 유효시간반빼와
+                iterator.remove();
+            }
+        }
         for(Meeting meeting : meetings) {
             if(meeting.getCategory().getValue().equals(category.getValue()))
                 count++;


### PR DESCRIPTION
## Related Issue 📌
- close #69 

## Description ✔️
- 기존의 pinlist, meeting detail list를 보여주는 api를 수정하는 pr입니다.
- 기존 pinlist api에서 번개가 개최된 pin의 list를 보여줬는데 이때 번개 시작시간이 현재 시간보다 빠른 번개들은 취급하지 않기로 변경했습니다.
- 기존 meeting detail list api에서 번개 시작 시간이 현재 시간보다 빠른 번개들은 번개 상세 정보를 제공하지 않도록 변경했습니다.

## To Reviewers
