### PR TITLE
[feat] 미팅 참여자 명단 api 생성

### DIFF
--- a/src/main/java/org/pingle/pingleserver/controller/MeetingController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/MeetingController.java
@@ -10,6 +10,7 @@ import org.pingle.pingleserver.domain.Meeting;
 import org.pingle.pingleserver.domain.Pin;
 import org.pingle.pingleserver.dto.common.ApiResponse;
 import org.pingle.pingleserver.dto.request.MeetingRequest;
+import org.pingle.pingleserver.dto.response.ParticipantsResponse;
 import org.pingle.pingleserver.dto.type.SuccessMessage;
 import org.pingle.pingleserver.service.MeetingService;
 import org.pingle.pingleserver.service.PinService;
@@ -46,5 +47,11 @@ public class MeetingController {
     public ApiResponse<?> cancelMeeting (@UserId Long userId, @PathVariable("meetingId") Long meetingId) {
         Long cancelledId = userMeetingService.cancelMeeting(userId, meetingId);
         return ApiResponse.success(SuccessMessage.OK);
+    }
+
+    @GetMapping("/{meetingId}/participants")
+    public ApiResponse<ParticipantsResponse> getMeetingParticipants (@PathVariable("meetingId") Long meetingId) {
+        return ApiResponse.success(SuccessMessage.OK, meetingService.getParticipants(meetingId));
+
     }
 }

--- a/src/main/java/org/pingle/pingleserver/domain/UserMeeting.java
+++ b/src/main/java/org/pingle/pingleserver/domain/UserMeeting.java
@@ -10,7 +10,7 @@ import org.pingle.pingleserver.domain.enums.MRole;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserMeeting extends BaseTimeEntity {
+public class UserMeeting extends BaseTimeEntity implements Comparable<UserMeeting> {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,5 +32,10 @@ public class UserMeeting extends BaseTimeEntity {
         this.user = user;
         this.meeting = meeting;
         this.meetingRole = meetingRole;
+    }
+
+    @Override
+    public int compareTo(UserMeeting o) {
+        return this.meetingRole.compareTo(o.meetingRole);
     }
 }

--- a/src/main/java/org/pingle/pingleserver/dto/request/MeetingRequest.java
+++ b/src/main/java/org/pingle/pingleserver/dto/request/MeetingRequest.java
@@ -29,18 +29,4 @@ public record MeetingRequest(@NotNull MCategory category,
                              @Min(2)@Max(99)
                              Integer maxParticipants,
                              String chatLink) {
-
-    @AssertTrue(message = "번개 종료 시각은 번개 생성보다 빠를 수 없습니다.")
-    public boolean isValidEndTime() {
-        try {
-            if(compareLocalDateTime(this.endAt() ,this.startAt()) < 0 )//startat 이전 false
-                return false;
-            return true;
-        } catch (RuntimeException e) {
-            throw new CustomException(ErrorMessage.BAD_REQUEST);
-        }
-    }
-    private static int compareLocalDateTime(LocalDateTime dateTime1, LocalDateTime dateTime2) {
-        return dateTime1.compareTo(dateTime2);
-    }
 }

--- a/src/main/java/org/pingle/pingleserver/dto/request/MeetingRequest.java
+++ b/src/main/java/org/pingle/pingleserver/dto/request/MeetingRequest.java
@@ -30,10 +30,10 @@ public record MeetingRequest(@NotNull MCategory category,
                              Integer maxParticipants,
                              String chatLink) {
 
-    @AssertTrue(message = "번개 시작 시간은 지금 시각 보다 전일 수 없습니다")
-    public boolean isValidStartTime() {
+    @AssertTrue(message = "번개 종료 시각은 번개 생성보다 빠를 수 없습니다.")
+    public boolean isValidEndTime() {
         try {
-            if(compareLocalDateTime(this.startAt() ,LocalDateTime.now()) < 0 )//startat 이전 false
+            if(compareLocalDateTime(this.endAt() ,this.startAt()) < 0 )//startat 이전 false
                 return false;
             return true;
         } catch (RuntimeException e) {

--- a/src/main/java/org/pingle/pingleserver/dto/response/ParticipantsResponse.java
+++ b/src/main/java/org/pingle/pingleserver/dto/response/ParticipantsResponse.java
@@ -1,0 +1,16 @@
+package org.pingle.pingleserver.dto.response;
+
+import org.pingle.pingleserver.domain.UserMeeting;
+
+import java.util.Collections;
+import java.util.List;
+
+public record ParticipantsResponse(
+        List<String> participants
+) {
+    public static ParticipantsResponse of(List<UserMeeting> userMeetings) {
+        Collections.sort(userMeetings);
+        List<String> participantNames = userMeetings.stream().map(userMeeting -> userMeeting.getUser().getName()).toList();
+        return new ParticipantsResponse(participantNames);
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/service/MeetingService.java
+++ b/src/main/java/org/pingle/pingleserver/service/MeetingService.java
@@ -3,10 +3,17 @@ package org.pingle.pingleserver.service;
 import lombok.RequiredArgsConstructor;
 import org.pingle.pingleserver.domain.Meeting;
 import org.pingle.pingleserver.domain.Pin;
+import org.pingle.pingleserver.domain.UserMeeting;
 import org.pingle.pingleserver.dto.request.MeetingRequest;
+import org.pingle.pingleserver.dto.response.ParticipantsResponse;
+import org.pingle.pingleserver.dto.type.ErrorMessage;
+import org.pingle.pingleserver.exception.CustomException;
 import org.pingle.pingleserver.repository.MeetingRepository;
+import org.pingle.pingleserver.repository.UserMeetingRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -14,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MeetingService {
 
     private final MeetingRepository meetingRepository;
+    private final UserMeetingRepository userMeetingRepository;
 
     @Transactional
     public Meeting createMeeting(MeetingRequest request, Pin pin) {
@@ -28,5 +36,12 @@ public class MeetingService {
                         .endAt(request.endAt())
                         .build());
 
+    }
+
+    public ParticipantsResponse getParticipants(Long meetingId) {
+        Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new CustomException(ErrorMessage.RESOURCE_NOT_FOUND));
+        List<UserMeeting> userMeetings = userMeetingRepository.findAllByMeeting(meeting);
+        return ParticipantsResponse.of(userMeetings);
     }
 }


### PR DESCRIPTION
## Related Issue 📌
- close #77 

## Description ✔️
- 번개의 참여자 명단을 불러오는 api입니다.
- response로 list의 첫번째 원소로 owner로 번개 개최자를 보내주고 이어서 참가자들을 보내줍니다.

## To Reviewers
