### PR TITLE
[fix] 미팅 생성 api, get meetings api 수정

### DIFF
--- a/src/main/java/org/pingle/pingleserver/controller/PinController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/PinController.java
@@ -21,13 +21,16 @@ public class PinController {
     private final PinService pinService;
 
     @GetMapping
-    public ApiResponse<List<PinResponse>> getPins (@PathVariable("teamId") Long teamId, @Nullable @RequestParam("category")MCategory category) {
+    public ApiResponse<List<PinResponse>> getPins (@PathVariable("teamId") Long teamId,
+                                                   @Nullable @RequestParam("category")MCategory category) {
         return ApiResponse.success(SuccessMessage.OK, pinService.getPins(teamId, category));
     }
 
     @GetMapping("/{pinId}/meetings")
-    public ApiResponse<List<MeetingResponse>> getMeetings(@UserId Long userId, @PathVariable("pinId") Long pinId,
-                                                          @Nullable @RequestParam("category")MCategory category) {
-        return ApiResponse.success(SuccessMessage.OK, pinService.getMeetingsDetail(userId, pinId, category));
+    public ApiResponse<List<MeetingResponse>> getMeetings(@UserId Long userId,
+                                                          @PathVariable String teamId,
+                                                          @PathVariable Long pinId,
+                                                          @Nullable @RequestParam MCategory category) {
+        return ApiResponse.success(SuccessMessage.OK, pinService.getMeetings(pinId, userId, category));
     }
 }

--- a/src/main/java/org/pingle/pingleserver/controller/PinController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/PinController.java
@@ -22,8 +22,7 @@ public class PinController {
 
     @GetMapping
     public ApiResponse<List<PinResponse>> getPins (@PathVariable("teamId") Long teamId, @Nullable @RequestParam("category")MCategory category) {
-        return ApiResponse.success(SuccessMessage.OK, pinService.getPinsFilterByCategory(teamId, category));
-
+        return ApiResponse.success(SuccessMessage.OK, pinService.getPins(teamId, category));
     }
 
     @GetMapping("/{pinId}/meetings")

--- a/src/main/java/org/pingle/pingleserver/domain/Pin.java
+++ b/src/main/java/org/pingle/pingleserver/domain/Pin.java
@@ -21,7 +21,7 @@ public class Pin extends BaseTimeEntity {
     private Team team;
 
     @OneToMany(mappedBy = "pin")
-    private List<Meeting> meetingList;
+    private List<Meeting> meetings;
 
     @Embedded
     private Point point;

--- a/src/main/java/org/pingle/pingleserver/dto/reponse/MeetingResponse.java
+++ b/src/main/java/org/pingle/pingleserver/dto/reponse/MeetingResponse.java
@@ -1,10 +1,26 @@
 package org.pingle.pingleserver.dto.reponse;
 
 import lombok.Builder;
+import org.pingle.pingleserver.domain.Meeting;
 import org.pingle.pingleserver.domain.enums.MCategory;
+
+import java.time.format.DateTimeFormatter;
 
 @Builder
 public record MeetingResponse(Long id, MCategory category, String name, String ownerName,
                               String location, String date, String startAt, String endAt, int maxParticipants,
                               int curParticipants, boolean isParticipating, String chatLink, boolean isOwner) {
+
+    public static MeetingResponse of(Meeting meeting, String ownerName, int curParticipants, boolean isParticipating, boolean isOwner) {
+        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss");
+
+        String date = meeting.getStartAt().format(dateFormatter);
+        String startAt = meeting.getStartAt().format(timeFormatter);
+        String endAt = meeting.getEndAt().format(timeFormatter);
+
+        return new MeetingResponse(meeting.getId(), meeting.getCategory(), meeting.getName(),
+                ownerName, meeting.getPin().getName(), date, startAt, endAt, meeting.getMaxParticipants(),
+                curParticipants, isParticipating, meeting.getChatLink(), isOwner);
+    }
 }

--- a/src/main/java/org/pingle/pingleserver/dto/reponse/PinResponse.java
+++ b/src/main/java/org/pingle/pingleserver/dto/reponse/PinResponse.java
@@ -8,6 +8,16 @@ import java.util.Comparator;
 import java.util.List;
 
 public record PinResponse(Long id, Double x, Double y, MCategory category, int meetingCount) {
+    public static PinResponse ofWithoutCategory(Pin pin) {
+        return new PinResponse(pin.getId(),pin.getPoint().getX(), pin.getPoint().getY(),
+                getMostRecentMeetingCategoryOfPin(pin), getMeetingCount(pin));
+    }
+
+    public static PinResponse ofWithCategory(Pin pin, MCategory category, int count) {
+        return new PinResponse(pin.getId(),pin.getPoint().getX(), pin.getPoint().getY(),
+                category, count);
+    }
+
     public static PinResponse ofWithNoFilter(Pin pin) {
         return new PinResponse(pin.getId(),pin.getPoint().getX(), pin.getPoint().getY(),
                 getMostRecentMeetingCategoryOfPin(pin), getMeetingCount(pin));
@@ -20,17 +30,17 @@ public record PinResponse(Long id, Double x, Double y, MCategory category, int m
     }
     private static MCategory getMostRecentMeetingCategoryOfPin (Pin pin) {
         Comparator<Meeting> comparator = Comparator.comparing(Meeting::getStartAt);
-        List<Meeting> meetingList = pin.getMeetingList();
+        List<Meeting> meetingList = pin.getMeetings();
         meetingList.sort(comparator);
         return meetingList.get(0).getCategory();
     }
 
     private static int getMeetingCount(Pin pin) {
-        return pin.getMeetingList().size();
+        return pin.getMeetings().size();
     }
     private static int getMeetingCountWithFilter(Pin pin, MCategory category) {
         int count = 0;
-        List<Meeting> meetings = pin.getMeetingList();
+        List<Meeting> meetings = pin.getMeetings();
         for(Meeting meeting : meetings) {
             if(meeting.getCategory().getValue().equals(category.getValue()))
                 count++;

--- a/src/main/java/org/pingle/pingleserver/dto/request/MeetingRequest.java
+++ b/src/main/java/org/pingle/pingleserver/dto/request/MeetingRequest.java
@@ -30,16 +30,28 @@ public record MeetingRequest(@NotNull MCategory category,
                              Integer maxParticipants,
                              String chatLink) {
 
-    @AssertTrue(message = "번개 시작 시간은 지금 시각 보다 전일 수 없습니다")
-    public boolean isValidStartTime() {
+    @AssertTrue(message = "번개 종료 시간은 시작 시간보다 전일 수 없습니다.")
+    public boolean isValidEndTime() {
         try {
-            if(compareLocalDateTime(this.startAt() ,LocalDateTime.now()) < 0 )//startat 이전 false
+            if(compareLocalDateTime(this.startAt() ,this.endAt()) > 0 )//startat 이후 false
                 return false;
             return true;
         } catch (RuntimeException e) {
             throw new CustomException(ErrorMessage.BAD_REQUEST);
         }
     }
+
+//    @AssertTrue(message = "번개 시작 시간은 지금 시각 보다 전일 수 없습니다")
+//    public boolean isValidStartTime() {
+//        try {
+//            if(compareLocalDateTime(this.startAt() ,LocalDateTime.now()) < 0 )//startat 이전 false
+//                return false;
+//            return true;
+//        } catch (RuntimeException e) {
+//            throw new CustomException(ErrorMessage.BAD_REQUEST);
+//        }
+//    }
+
     private static int compareLocalDateTime(LocalDateTime dateTime1, LocalDateTime dateTime2) {
         return dateTime1.compareTo(dateTime2);
     }

--- a/src/main/java/org/pingle/pingleserver/repository/MeetingRepository.java
+++ b/src/main/java/org/pingle/pingleserver/repository/MeetingRepository.java
@@ -1,7 +1,11 @@
 package org.pingle.pingleserver.repository;
 
 import org.pingle.pingleserver.domain.Meeting;
+import org.pingle.pingleserver.domain.enums.MCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+    @Query("SELECT COUNT(m) FROM Meeting m WHERE m.pin.id = :pinId AND m.startAt > CURRENT_TIMESTAMP AND m.category = :category")
+    int countMeetingsForPin(Long pinId, MCategory category);
 }

--- a/src/main/java/org/pingle/pingleserver/repository/MeetingRepository.java
+++ b/src/main/java/org/pingle/pingleserver/repository/MeetingRepository.java
@@ -5,7 +5,14 @@ import org.pingle.pingleserver.domain.enums.MCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     @Query("SELECT COUNT(m) FROM Meeting m WHERE m.pin.id = :pinId AND m.startAt > CURRENT_TIMESTAMP AND m.category = :category")
     int countMeetingsForPin(Long pinId, MCategory category);
+
+    List<Meeting> findByPinIdAndCategoryAndStartAtAfter(Long pinId, MCategory category, LocalDateTime currentTime);
+
+    List<Meeting> findByPinIdAndStartAtAfter(Long pinId, LocalDateTime currentTime);
 }

--- a/src/main/java/org/pingle/pingleserver/repository/PinRepository.java
+++ b/src/main/java/org/pingle/pingleserver/repository/PinRepository.java
@@ -3,7 +3,9 @@ package org.pingle.pingleserver.repository;
 import org.pingle.pingleserver.domain.Pin;
 import org.pingle.pingleserver.domain.Team;
 import org.pingle.pingleserver.domain.Point;
+import org.pingle.pingleserver.domain.enums.MCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -11,4 +13,12 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
     List<Pin> findAllByTeam(Team team);
     boolean existsByPointAndTeam(Point point, Team team);
     Pin findByPointAndTeam(Point point, Team team);
+    @Query("SELECT DISTINCT p FROM Pin p WHERE p.team.id = :teamId AND p.id IN (SELECT m.pin.id FROM Meeting m WHERE m.startAt > CURRENT_TIMESTAMP AND m.category = :category)")
+    List<Pin> findPinsWithCategoryAndTimeBefore(Long teamId, MCategory category);
+    @Query("SELECT DISTINCT p FROM Pin p WHERE p.team.id = :teamId AND p.id IN (SELECT m.pin.id FROM Meeting m WHERE m.startAt > CURRENT_TIMESTAMP)")
+    List<Pin> findPinsAndTimeBefore(Long teamId);
+
+    // todo: use native query to solve n+1 problem
+//    @Query(value = "SELECT p.*, COUNT(m.id) FROM pin p LEFT JOIN meeting m ON p.id = m.pin_id WHERE p.team_id = :teamId AND m.start_at > CURRENT_TIMESTAMP AND m.category = :category GROUP BY p.id", nativeQuery = true)
+//    List<PinResponse> test(Long teamId, MCategory category);
 }

--- a/src/main/java/org/pingle/pingleserver/service/PinService.java
+++ b/src/main/java/org/pingle/pingleserver/service/PinService.java
@@ -123,6 +123,21 @@ public class PinService {
         return pins.stream()
                 .map(pin -> PinResponse.ofWithCategory(pin, category, meetingRepository.countMeetingsForPin(pin.getId(), category))).toList();
     }
+
+    public List<MeetingResponse> getMeetings(Long pinId, Long userId, MCategory category){
+        List<Meeting> meetings;
+
+        if (category == null){
+            meetings = meetingRepository.findByPinIdAndStartAtAfter(pinId, LocalDateTime.now());
+        } else {
+            meetings = meetingRepository.findByPinIdAndCategoryAndStartAtAfter(pinId, category, LocalDateTime.now());
+        }
+        return meetings.stream()
+                .map(meeting -> MeetingResponse.of(meeting, getOwnerName(meeting), getCurParticipants(meeting),
+                        isParticipating(userId, meeting), isOwner(userId, meeting.getId()))).toList();
+
+
+    }
   
     private boolean checkMeetingsCategoryOfPin(Pin pin, MCategory category) {
         List<Meeting> meetingList = pin.getMeetings();


### PR DESCRIPTION
## Related Issue 📌
- close #69 

## Description ✔️
- 애플리케이션 단에서 여러번 돌아가는 로직을 JPQL을 사용해서 다듬었습니다.
- Native Query를 통해서 count도 한 번에 가져오도록 수정할 수 있을 것 같지만 조사가 더 필요할 것 같아서 아직 적용하지 않았습니다.
- 미팅 생성은 끝나는 시간이 시작하는 시간보다 빠르면 생성이 불가능합니다
- 미팅 리스트에도 쿼리 파라미터를 추가했습니다.