### PR TITLE
[feat] 미팅 삭제 api 생성

### DIFF
--- a/src/main/java/org/pingle/pingleserver/controller/MeetingController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/MeetingController.java
@@ -52,6 +52,11 @@ public class MeetingController {
     @GetMapping("/{meetingId}/participants")
     public ApiResponse<ParticipantsResponse> getMeetingParticipants (@PathVariable("meetingId") Long meetingId) {
         return ApiResponse.success(SuccessMessage.OK, meetingService.getParticipants(meetingId));
+    }
 
+    @DeleteMapping("/{meetingId}")
+    public ApiResponse<?> deleteMeeting(@UserId Long userId, @PathVariable("meetingId") Long meetingId) {
+        meetingService.deleteMeeting(userId, meetingId);
+        return ApiResponse.success(SuccessMessage.OK);
     }
 }

--- a/src/main/java/org/pingle/pingleserver/domain/Meeting.java
+++ b/src/main/java/org/pingle/pingleserver/domain/Meeting.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import org.pingle.pingleserver.domain.enums.MCategory;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -20,6 +22,9 @@ public class Meeting extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "pin_id")
     private Pin pin;
+
+    @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL)
+    private List<UserMeeting> userMeetingList = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     private MCategory category;

--- a/src/main/java/org/pingle/pingleserver/dto/type/ErrorMessage.java
+++ b/src/main/java/org/pingle/pingleserver/dto/type/ErrorMessage.java
@@ -32,6 +32,7 @@ public enum ErrorMessage {
     EMPTY_PRINCIPAL(HttpStatus.UNAUTHORIZED, "내부적으로 유저 정보를 받는데 실패했습니다"),
     // Permission Denied 403
     GROUP_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "해당 사용자는 그룹에 속해 있지 않습니다."),
+    PERMISSION_DENIED(HttpStatus.FORBIDDEN, "권한이 없습니다"),
     // Not Found Error 404
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 리소스가 존재하지 않습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),

--- a/src/main/java/org/pingle/pingleserver/repository/UserMeetingRepository.java
+++ b/src/main/java/org/pingle/pingleserver/repository/UserMeetingRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 
 public interface UserMeetingRepository extends JpaRepository<UserMeeting, Long> {
     Optional<UserMeeting> findByMeetingAndMeetingRole(Meeting meeting, MRole role);
+    Optional<UserMeeting> findByUserIdAndMeeting(Long userId, Meeting meeting);
     List<UserMeeting> findAllByMeeting(Meeting meeting);
     boolean existsByUserIdAndMeeting(Long userId, Meeting meeting);
     Optional<UserMeeting> findByUserIdAndMeetingId(Long userId, Long MeetingId);

--- a/src/main/java/org/pingle/pingleserver/service/MeetingService.java
+++ b/src/main/java/org/pingle/pingleserver/service/MeetingService.java
@@ -35,7 +35,6 @@ public class MeetingService {
                         .startAt(request.startAt())
                         .endAt(request.endAt())
                         .build());
-
     }
 
     public ParticipantsResponse getParticipants(Long meetingId) {
@@ -43,5 +42,14 @@ public class MeetingService {
                 .orElseThrow(() -> new CustomException(ErrorMessage.RESOURCE_NOT_FOUND));
         List<UserMeeting> userMeetings = userMeetingRepository.findAllByMeeting(meeting);
         return ParticipantsResponse.of(userMeetings);
+    }
+
+    @Transactional
+    public void deleteMeeting(Long userId, Long meetingId) {
+        Meeting meeting = meetingRepository.findById(meetingId).orElseThrow(() -> new CustomException(ErrorMessage.RESOURCE_NOT_FOUND));
+        UserMeeting userMeeting = userMeetingRepository.findByUserIdAndMeeting(userId, meeting).orElseThrow(() -> new CustomException(ErrorMessage.RESOURCE_NOT_FOUND));
+        if(userMeeting.getMeetingRole().getValue().equals("participants"))
+            throw new CustomException(ErrorMessage.PERMISSION_DENIED);
+        meetingRepository.delete(meeting);
     }
 }


### PR DESCRIPTION
## Related Issue 📌
- close #87 

## Description ✔️
- 미팅을 삭제하는 api입니다.
- Meeting Role이 owner인 사람만 사용할 수 있는 api입니다.
- participants가 해당 api 호출시 403에러를 발생합니다.

## To Reviewers
CascadeType.ALL을 사용하여 미팅이 지워질 시 연관된 유저미팅이 함께 지워지도록 설정하였습니다.