### PR TITLE
[feat] 단체 생성 flow

### DIFF
--- a/src/main/java/org/pingle/pingleserver/controller/TeamController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/TeamController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.pingle.pingleserver.annotation.UserId;
 import org.pingle.pingleserver.controller.swagger.TeamApi;
 import org.pingle.pingleserver.dto.common.ApiResponse;
+import org.pingle.pingleserver.dto.reponse.TeamNameDuplicatedResponse;
 import org.pingle.pingleserver.dto.request.TeamRegisterRequest;
 import org.pingle.pingleserver.dto.response.SelectedTeamResponse;
 import org.pingle.pingleserver.dto.response.TeamRegisterResponse;
@@ -39,5 +40,10 @@ public class TeamController implements TeamApi {
             @PathVariable Long teamId,
             @Valid @RequestBody TeamRegisterRequest request){
         return ApiResponse.success(SuccessMessage.OK, teamService.registerTeam(userId, teamId, request));
+    }
+
+    @GetMapping("/check-name")
+    public ApiResponse<TeamNameDuplicatedResponse> checkTeamName(@NotBlank @RequestParam String name){
+        return ApiResponse.success(SuccessMessage.OK, teamService.checkTeamName(name));
     }
 }

--- a/src/main/java/org/pingle/pingleserver/controller/TeamController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/TeamController.java
@@ -6,7 +6,9 @@ import lombok.RequiredArgsConstructor;
 import org.pingle.pingleserver.annotation.UserId;
 import org.pingle.pingleserver.controller.swagger.TeamApi;
 import org.pingle.pingleserver.dto.common.ApiResponse;
+import org.pingle.pingleserver.dto.reponse.TeamCreationResponse;
 import org.pingle.pingleserver.dto.reponse.TeamNameDuplicatedResponse;
+import org.pingle.pingleserver.dto.request.TeamCreationRequest;
 import org.pingle.pingleserver.dto.request.TeamRegisterRequest;
 import org.pingle.pingleserver.dto.response.SelectedTeamResponse;
 import org.pingle.pingleserver.dto.response.TeamRegisterResponse;
@@ -45,5 +47,10 @@ public class TeamController implements TeamApi {
     @GetMapping("/check-name")
     public ApiResponse<TeamNameDuplicatedResponse> checkTeamName(@NotBlank @RequestParam String name){
         return ApiResponse.success(SuccessMessage.OK, teamService.checkTeamName(name));
+    }
+
+    @PostMapping
+    public ApiResponse<TeamCreationResponse> createTeam(@UserId Long userId, @Valid @RequestBody TeamCreationRequest request){
+        return ApiResponse.success(SuccessMessage.OK, teamService.createTeam(userId, request));
     }
 }

--- a/src/main/java/org/pingle/pingleserver/domain/Team.java
+++ b/src/main/java/org/pingle/pingleserver/domain/Team.java
@@ -2,6 +2,7 @@ package org.pingle.pingleserver.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.pingle.pingleserver.domain.enums.TKeyword;
@@ -21,6 +22,16 @@ public class Team extends BaseTimeEntity {
 
     private String code;
 
+    private String email;
+
     @Enumerated(EnumType.STRING)
     private TKeyword keyword;
+
+    @Builder
+    public Team(String name, String email, String code, TKeyword keyword) {
+        this.name = name;
+        this.email = email;
+        this.code = code;
+        this.keyword = keyword;
+    }
 }

--- a/src/main/java/org/pingle/pingleserver/dto/reponse/TeamCreationResponse.java
+++ b/src/main/java/org/pingle/pingleserver/dto/reponse/TeamCreationResponse.java
@@ -1,0 +1,16 @@
+package org.pingle.pingleserver.dto.reponse;
+
+import org.pingle.pingleserver.domain.Team;
+import org.pingle.pingleserver.domain.enums.TKeyword;
+
+public record TeamCreationResponse (
+        Long id,
+        String name,
+        String email,
+        String code,
+        TKeyword keyword
+) {
+    public static TeamCreationResponse of(Team team) {
+        return new TeamCreationResponse(team.getId(), team.getName(), team.getEmail(), team.getCode(), team.getKeyword());
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/dto/reponse/TeamNameDuplicatedResponse.java
+++ b/src/main/java/org/pingle/pingleserver/dto/reponse/TeamNameDuplicatedResponse.java
@@ -1,0 +1,4 @@
+package org.pingle.pingleserver.dto.reponse;
+
+public record TeamNameDuplicatedResponse (boolean result){
+}

--- a/src/main/java/org/pingle/pingleserver/dto/request/TeamCreationRequest.java
+++ b/src/main/java/org/pingle/pingleserver/dto/request/TeamCreationRequest.java
@@ -1,0 +1,10 @@
+package org.pingle.pingleserver.dto.request;
+
+import org.pingle.pingleserver.domain.enums.TKeyword;
+
+public record TeamCreationRequest (
+        String name,
+        String email,
+        TKeyword keyword
+) {
+}

--- a/src/main/java/org/pingle/pingleserver/dto/type/ErrorMessage.java
+++ b/src/main/java/org/pingle/pingleserver/dto/type/ErrorMessage.java
@@ -27,6 +27,7 @@ public enum ErrorMessage {
     MISSING_REQUIRED_HEADER(HttpStatus.BAD_REQUEST, "필수 헤더가 누락되었습니다."),
     MISSING_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다."),
     GROUP_OWNER_DELETION_DENIED(HttpStatus.BAD_REQUEST, "그룹 장은 탈퇴할 수 없습니다."),
+    DUPLICATED_TEAM_NAME(HttpStatus.BAD_REQUEST, "중복된 팀 이름입니다."),
     // Authorization Error 401
     TOKEN_MALFORMED_ERROR(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     UNAUTHORIZED_ERROR(HttpStatus.UNAUTHORIZED, "토큰이 제공되지 않았거나 유효하지 않습니다."),

--- a/src/main/java/org/pingle/pingleserver/repository/TeamRepository.java
+++ b/src/main/java/org/pingle/pingleserver/repository/TeamRepository.java
@@ -25,4 +25,6 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
             "WHERE t.id = :teamId " +
             "GROUP BY t")
     Optional<TeamDetailDto> findTeamDetailsWithCounts(Long teamId);
+
+    boolean existsByNameIgnoreCase(String name);
 }

--- a/src/main/java/org/pingle/pingleserver/service/TeamService.java
+++ b/src/main/java/org/pingle/pingleserver/service/TeamService.java
@@ -5,7 +5,9 @@ import org.pingle.pingleserver.domain.Team;
 import org.pingle.pingleserver.domain.User;
 import org.pingle.pingleserver.domain.UserTeam;
 import org.pingle.pingleserver.domain.enums.TRole;
+import org.pingle.pingleserver.dto.reponse.TeamCreationResponse;
 import org.pingle.pingleserver.dto.reponse.TeamNameDuplicatedResponse;
+import org.pingle.pingleserver.dto.request.TeamCreationRequest;
 import org.pingle.pingleserver.dto.request.TeamRegisterRequest;
 import org.pingle.pingleserver.dto.response.SelectedTeamResponse;
 import org.pingle.pingleserver.dto.response.TeamDetailDto;
@@ -23,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.Random;
 
 @Service
 @RequiredArgsConstructor
@@ -70,5 +73,40 @@ public class TeamService {
 
     public TeamNameDuplicatedResponse checkTeamName(String name) {
         return new TeamNameDuplicatedResponse(!teamRepository.existsByNameIgnoreCase(name));
+    }
+
+    @Transactional
+    public TeamCreationResponse createTeam(Long userId, TeamCreationRequest request) {
+        User user = userRepository.findByIdOrThrow(userId);
+
+        String code = generateCode();
+        Team team = Team.builder()
+                .name(request.name())
+                .email(request.email())
+                .keyword(request.keyword())
+                .code(code)
+                .build();
+        teamRepository.save(team);
+
+        UserTeam userTeam = UserTeam.builder()
+                .user(user)
+                .team(team)
+                .teamRole(TRole.OWNER)
+                .build();
+        userTeamRepository.save(userTeam);
+
+        return TeamCreationResponse.of(team);
+    }
+
+    private String generateCode() {
+        String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        StringBuilder result = new StringBuilder(12);
+        Random random = new Random();
+
+        for (int i = 0; i < 12; i++) {
+            int index = random.nextInt(characters.length());
+            result.append(characters.charAt(index));
+        }
+        return result.toString();
     }
 }

--- a/src/main/java/org/pingle/pingleserver/service/TeamService.java
+++ b/src/main/java/org/pingle/pingleserver/service/TeamService.java
@@ -5,6 +5,7 @@ import org.pingle.pingleserver.domain.Team;
 import org.pingle.pingleserver.domain.User;
 import org.pingle.pingleserver.domain.UserTeam;
 import org.pingle.pingleserver.domain.enums.TRole;
+import org.pingle.pingleserver.dto.reponse.TeamNameDuplicatedResponse;
 import org.pingle.pingleserver.dto.request.TeamRegisterRequest;
 import org.pingle.pingleserver.dto.response.SelectedTeamResponse;
 import org.pingle.pingleserver.dto.response.TeamDetailDto;
@@ -65,5 +66,9 @@ public class TeamService {
                 .build();
         userTeamRepository.save(newUserTeam);
         return TeamRegisterResponse.of(team.getId(), team.getName());
+    }
+
+    public TeamNameDuplicatedResponse checkTeamName(String name) {
+        return new TeamNameDuplicatedResponse(!teamRepository.existsByNameIgnoreCase(name));
     }
 }

--- a/src/main/java/org/pingle/pingleserver/service/TeamService.java
+++ b/src/main/java/org/pingle/pingleserver/service/TeamService.java
@@ -78,6 +78,9 @@ public class TeamService {
     @Transactional
     public TeamCreationResponse createTeam(Long userId, TeamCreationRequest request) {
         User user = userRepository.findByIdOrThrow(userId);
+        if (teamRepository.existsByNameIgnoreCase(request.name())) {
+            throw new CustomException(ErrorMessage.DUPLICATED_TEAM_NAME);
+        }
 
         String code = generateCode();
         Team team = Team.builder()


### PR DESCRIPTION
## Related Issue 📌
- close #107 

## Description ✔️
- 단체 생성 플로우 관련 API 제작
- Team 엔티티에 email 필드 추가

단체 생성할 때 중복 생성 불가능하게 하는 로직이 있어야하는데 안했네요, 추가하겠습니다.
