### PR TITLE
[feat] 장소 랭킹 api 생성

### DIFF
--- a/src/main/java/org/pingle/pingleserver/controller/PinController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/PinController.java
@@ -8,6 +8,7 @@ import org.pingle.pingleserver.domain.enums.MCategory;
 import org.pingle.pingleserver.dto.common.ApiResponse;
 import org.pingle.pingleserver.dto.reponse.MeetingResponse;
 import org.pingle.pingleserver.dto.reponse.PinResponse;
+import org.pingle.pingleserver.dto.response.RankingResponse;
 import org.pingle.pingleserver.dto.type.SuccessMessage;
 import org.pingle.pingleserver.service.PinService;
 import org.springframework.web.bind.annotation.*;
@@ -33,5 +34,11 @@ public class PinController implements PinApi {
                                                           @PathVariable Long pinId,
                                                           @Nullable @RequestParam MCategory category) {
         return ApiResponse.success(SuccessMessage.OK, pinService.getMeetings(pinId, userId, category));
+    }
+
+    @GetMapping("/ranking")
+    public ApiResponse<RankingResponse> getRankings(@PathVariable Long teamId) {
+        return ApiResponse.success(SuccessMessage.OK, pinService.getRankings(teamId));
+
     }
 }

--- a/src/main/java/org/pingle/pingleserver/dto/response/RankingIndividualResponse.java
+++ b/src/main/java/org/pingle/pingleserver/dto/response/RankingIndividualResponse.java
@@ -1,0 +1,6 @@
+package org.pingle.pingleserver.dto.response;
+
+import java.time.LocalDateTime;
+
+public record RankingIndividualResponse (String name, LocalDateTime latestVisitedDate, Long locationCount) {
+}

--- a/src/main/java/org/pingle/pingleserver/dto/response/RankingResponse.java
+++ b/src/main/java/org/pingle/pingleserver/dto/response/RankingResponse.java
@@ -1,0 +1,17 @@
+package org.pingle.pingleserver.dto.response;
+
+import java.util.List;
+
+public record RankingResponse (int meetingCount, List<RankingIndividualResponse> locations)  {
+    public static RankingResponse of (List<RankingIndividualResponse> responses) {
+        return new RankingResponse(getSumOfMeetings(responses), responses);
+    }
+
+    private static int getSumOfMeetings (List<RankingIndividualResponse> responses) {
+        int sum = 0;
+        for (RankingIndividualResponse response : responses) {
+            sum += response.locationCount();
+        }
+        return sum;
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/repository/PinRepository.java
+++ b/src/main/java/org/pingle/pingleserver/repository/PinRepository.java
@@ -4,6 +4,7 @@ import org.pingle.pingleserver.domain.Pin;
 import org.pingle.pingleserver.domain.Team;
 import org.pingle.pingleserver.domain.Point;
 import org.pingle.pingleserver.domain.enums.MCategory;
+import org.pingle.pingleserver.dto.response.RankingIndividualResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -17,6 +18,12 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
     List<Pin> findPinsWithCategoryAndTimeBefore(Long teamId, MCategory category);
     @Query("SELECT DISTINCT p FROM Pin p WHERE p.team.id = :teamId AND p.id IN (SELECT m.pin.id FROM Meeting m WHERE m.startAt > CURRENT_TIMESTAMP)")
     List<Pin> findPinsAndTimeBefore(Long teamId);
+    @Query("select new org.pingle.pingleserver.dto.response.RankingIndividualResponse(p.name, max(m.endAt), count(p)) " +
+            "from Meeting m join m.pin p " +
+            "WHERE m.endAt < CURRENT_TIMESTAMP AND p.team.id = :teamId " +
+            "group by p " +
+            "order by count(p) desc, max(m.endAt) desc")
+    List<RankingIndividualResponse> findPinsWithMeetingsBeforeCurrentTimestampAndTeamId(Long teamId);
 
     // todo: use native query to solve n+1 problem
 //    @Query(value = "SELECT p.*, COUNT(m.id) FROM pin p LEFT JOIN meeting m ON p.id = m.pin_id WHERE p.team_id = :teamId AND m.start_at > CURRENT_TIMESTAMP AND m.category = :category GROUP BY p.id", nativeQuery = true)

--- a/src/main/java/org/pingle/pingleserver/service/PinService.java
+++ b/src/main/java/org/pingle/pingleserver/service/PinService.java
@@ -12,6 +12,8 @@ import org.pingle.pingleserver.dto.reponse.PinResponse;
 import org.pingle.pingleserver.domain.Address;
 import org.pingle.pingleserver.domain.Point;
 import org.pingle.pingleserver.dto.request.MeetingRequest;
+import org.pingle.pingleserver.dto.response.RankingIndividualResponse;
+import org.pingle.pingleserver.dto.response.RankingResponse;
 import org.pingle.pingleserver.dto.type.ErrorMessage;
 import org.pingle.pingleserver.exception.CustomException;
 import org.pingle.pingleserver.repository.MeetingRepository;
@@ -160,5 +162,11 @@ public class PinService {
 
     private boolean isOwner(Long userId, Long meetingId) {
         return userMeetingRepository.existsByUserIdAndMeetingIdAndMeetingRole(userId, meetingId, MRole.OWNER);
+    }
+
+    public RankingResponse getRankings(Long teamId) {
+        if(!teamRepository.existsById(teamId)) throw new CustomException(ErrorMessage.RESOURCE_NOT_FOUND);
+        List<RankingIndividualResponse> response = pinRepository.findPinsWithMeetingsBeforeCurrentTimestampAndTeamId(teamId);
+        return RankingResponse.of(response);
     }
 }


### PR DESCRIPTION
## Related Issue 📌
- close #109

## Description ✔️
- 랭킹 검색 api입니다.
- response에 상태가 done인 번개의 숫자와 랭킹 배열을 반환합니다
- 랭킹배열에는 장소이름, 해당 장소에서 가장 최근에 끝난 번개의 시간, 해당 장소에서 끝난 번개의 수를 반환합니다.
- 랭킹 배열은 1. 해당 장소에서 끝난 번개의 수 2. 해당 장소에서 가장 최근에 끝난 번개의 시간을 기준으로 내림차순으로 정렬됩니다. 

## To Reviewers
