### PR TITLE
회원 탈퇴 시 팀 미탈퇴 이슈 수정

### DIFF
--- a/src/main/java/org/pingle/pingleserver/service/UserService.java
+++ b/src/main/java/org/pingle/pingleserver/service/UserService.java
@@ -14,6 +14,7 @@ import org.pingle.pingleserver.oauth.service.AppleLoginService;
 import org.pingle.pingleserver.repository.MeetingRepository;
 import org.pingle.pingleserver.repository.UserMeetingRepository;
 import org.pingle.pingleserver.repository.UserRepository;
+import org.pingle.pingleserver.repository.UserTeamRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +30,7 @@ public class UserService {
     private final AppleLoginService appleLoginService;
     private final MeetingRepository meetingRepository;
     private final UserMeetingRepository userMeetingRepository;
+    private final UserTeamRepository userTeamRepository;
 
     public UserInfoResponse getUserInfo(Long userId) {
         User user = userRepository.findByIdAndIsDeletedOrThrow(userId, false);
@@ -58,7 +60,7 @@ public class UserService {
         if (hasAdminRole) {
             throw new CustomException(ErrorMessage.GROUP_OWNER_DELETION_DENIED);
         }
-        user.getUserTeams().clear();
+        userTeamRepository.deleteAll(user.getUserTeams());
     }
 
     private void leaveMeetings (User user){


### PR DESCRIPTION
## Related Issue 📌
- close #119 

## Description ✔️
- clear라는 잘못된 문법으로 작성된 코드를 repository의 deleteAll로 수정

## To Reviewers
일전에 테스트 방식이 잘못됐었던 것 같습니다. 실제로는 작동하지 않는 코드여서 수정했습니다. 죄송합니다.