### PR TITLE
[feat] dev 서버용 토큰 발행 api 제작

### DIFF
--- a/src/main/java/org/pingle/pingleserver/controller/TestController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/TestController.java
@@ -1,0 +1,32 @@
+package org.pingle.pingleserver.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.pingle.pingleserver.domain.enums.URole;
+import org.pingle.pingleserver.repository.UserRepository;
+import org.pingle.pingleserver.utils.JwtUtil;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@Profile({"local", "dev"})
+@RequestMapping("/test")
+@RequiredArgsConstructor
+public class TestController {
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+
+    @Value("${token-test.key}")
+    private String key;
+
+    @GetMapping("/token/{userId}")
+    public ResponseEntity<?> getToken(@PathVariable("userId") Long userId,
+                                                     @RequestHeader(value = "Test-Key", required = false) String testKey){
+        if (!key.isBlank() && !key.equals(testKey)) {
+            return ResponseEntity.badRequest().body("Invalid test key");
+        }
+        userRepository.findByIdOrThrow(userId);
+        return ResponseEntity.ok(jwtUtil.generateTokens(userId, URole.USER));
+    }
+}


### PR DESCRIPTION
## Related Issue 📌
- close #121 

## Description ✔️
- 클라이언트에서 지속적으로 요구하는 다른 유저의 accessToken을 반환하기 위해 local, dev에서만 작동하는 API를 제작했습니다.
- local의 경우에는 비밀번호 없이 사용 가능하지만 dev의 경우에는 악용될 우려가 있어 헤더에 비밀번호를 입력해야 사용 가능합니다.

## To Reviewers
- 일단 필요할 것 같아서 생각나는대로 만들어봤습니다. 나중에 여유로워졌을 때 더 좋은 아이디어가 떠오르면 바꿀 예정입니다. 아이디어 있으면 언제든 추천 받습니다.