### PR TITLE
[feat] 분산락을 통한 참여 로직 동시성 제어

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ application-secret.properties
 application-local.yml
 application-dev.yml
 application-prod.yml
+application-test.yml
 
 ### Java ###
 # Compiled class file

--- a/src/main/java/org/pingle/pingleserver/config/DataSourceConfiguration.java
+++ b/src/main/java/org/pingle/pingleserver/config/DataSourceConfiguration.java
@@ -2,14 +2,12 @@ package org.pingle.pingleserver.config;
 
 import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-import com.zaxxer.hikari.HikariDataSource;
 
 @Configuration
 @EnableConfigurationProperties

--- a/src/main/java/org/pingle/pingleserver/config/DataSourceConfiguration.java
+++ b/src/main/java/org/pingle/pingleserver/config/DataSourceConfiguration.java
@@ -1,0 +1,35 @@
+package org.pingle.pingleserver.config;
+
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import com.zaxxer.hikari.HikariDataSource;
+
+@Configuration
+@EnableConfigurationProperties
+public class DataSourceConfiguration {
+
+    @Bean
+    @Primary
+    @ConfigurationProperties(prefix = "spring.datasource.jpa")
+    DataSource jpaDataSource() {
+        return DataSourceBuilder
+                .create()
+                .build();
+    }
+
+    @Bean
+    @Qualifier("lockDataSource")
+    @ConfigurationProperties(prefix = "spring.datasource.lock")
+    DataSource lockDataSource() {
+        return DataSourceBuilder
+                .create()
+                .build();
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/controller/MeetingController.java
+++ b/src/main/java/org/pingle/pingleserver/controller/MeetingController.java
@@ -16,6 +16,7 @@ import org.pingle.pingleserver.dto.request.MeetingRequest;
 import org.pingle.pingleserver.dto.response.ParticipantsResponse;
 import org.pingle.pingleserver.dto.response.SearchResponse;
 import org.pingle.pingleserver.dto.type.SuccessMessage;
+import org.pingle.pingleserver.service.MeetingParticipateFacade;
 import org.pingle.pingleserver.service.MeetingService;
 import org.pingle.pingleserver.service.PinService;
 
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.*;
 public class MeetingController implements MeetingApi {
 
     private final MeetingService meetingService;
+    private final MeetingParticipateFacade meetingParticipateFacade;
     private final UserMeetingService userMeetingService;
     private final PinService pinService;
 
@@ -43,7 +45,7 @@ public class MeetingController implements MeetingApi {
 
     @PostMapping("/{meetingId}/join")
     public ApiResponse<?> participateMeeting (@UserId Long userId, @PathVariable("meetingId") Long meetingId) {
-        Long userMeetingId = userMeetingService.participateMeeting(userId, meetingId);
+        meetingParticipateFacade.participateWithLock(userId, meetingId);
         return ApiResponse.success(SuccessMessage.CREATED);
     }
 

--- a/src/main/java/org/pingle/pingleserver/domain/Meeting.java
+++ b/src/main/java/org/pingle/pingleserver/domain/Meeting.java
@@ -1,15 +1,24 @@
 package org.pingle.pingleserver.domain;
 
-import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import org.pingle.pingleserver.domain.enums.MCategory;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.pingle.pingleserver.domain.enums.MCategory;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter

--- a/src/main/java/org/pingle/pingleserver/domain/UserMeeting.java
+++ b/src/main/java/org/pingle/pingleserver/domain/UserMeeting.java
@@ -9,6 +9,11 @@ import org.pingle.pingleserver.domain.enums.MRole;
 
 @Entity
 @Getter
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(name = "unique_user_meeting", columnNames = {"user_id", "meeting_id"})
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserMeeting extends BaseTimeEntity implements Comparable<UserMeeting> {
 

--- a/src/main/java/org/pingle/pingleserver/service/LockManager.java
+++ b/src/main/java/org/pingle/pingleserver/service/LockManager.java
@@ -1,0 +1,5 @@
+package org.pingle.pingleserver.service;
+
+public interface LockManager {
+    void executeWithLock(String key, Runnable runnable);
+}

--- a/src/main/java/org/pingle/pingleserver/service/MeetingParticipateFacade.java
+++ b/src/main/java/org/pingle/pingleserver/service/MeetingParticipateFacade.java
@@ -1,0 +1,16 @@
+package org.pingle.pingleserver.service;
+
+import org.springframework.stereotype.Service;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingParticipateFacade {
+    private final UserMeetingService userMeetingService;
+    private final LockManager lockManager;
+
+    public void participateWithLock(Long userId, Long meetingId) {
+        lockManager.executeWithLock(meetingId.toString(),
+                () -> userMeetingService.participateMeeting(userId, meetingId));
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/service/MeetingService.java
+++ b/src/main/java/org/pingle/pingleserver/service/MeetingService.java
@@ -1,6 +1,10 @@
 package org.pingle.pingleserver.service;
 
-import lombok.RequiredArgsConstructor;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.pingle.pingleserver.domain.Meeting;
 import org.pingle.pingleserver.domain.Pin;
 import org.pingle.pingleserver.domain.UserMeeting;
@@ -20,12 +24,7 @@ import org.pingle.pingleserver.repository.UserMeetingRepository;
 import org.pingle.pingleserver.utils.SlackUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/pingle/pingleserver/service/UserMeetingService.java
+++ b/src/main/java/org/pingle/pingleserver/service/UserMeetingService.java
@@ -46,7 +46,8 @@ public class UserMeetingService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Long participateMeeting(Long userId, Long meetingId) {
         Meeting meeting = meetingRepository.findById(meetingId).orElseThrow(() -> new CustomException(ErrorMessage.MEETING_NOT_FOUND));
-        validateParticipateCondition(userId, meeting);
+        if((getCurParticipants(meeting)) >= meeting.getMaxParticipants())
+            throw new CustomException(ErrorMessage.RESOURCE_CONFLICT);
         User user = userRepository.findByIdOrThrow(userId);
         Long participateId;
         try{
@@ -73,12 +74,5 @@ public class UserMeetingService {
 
     private boolean isParticipating(Long userId, Meeting meeting) {
         return userMeetingRepository.existsByUserIdAndMeeting(userId, meeting);
-    }
-
-    private void validateParticipateCondition(Long userId, Meeting meeting) {
-        if(isParticipating(userId, meeting))
-            throw new CustomException(ErrorMessage.RESOURCE_CONFLICT);
-        if((getCurParticipants(meeting)) >= meeting.getMaxParticipants())
-            throw new CustomException(ErrorMessage.RESOURCE_CONFLICT);
     }
 }

--- a/src/main/java/org/pingle/pingleserver/service/lock/DatabaseLockManager.java
+++ b/src/main/java/org/pingle/pingleserver/service/lock/DatabaseLockManager.java
@@ -38,7 +38,7 @@ public class DatabaseLockManager implements LockManager {
         try (PreparedStatement stmt = connection.prepareStatement(sql)) {
             stmt.setString(1, key);
             stmt.setInt(2, 3000);
-            stmt.executeQuery(); // 락 key 획득 시도, 무한 대기
+            stmt.executeQuery();
         } catch (SQLException e) {
             throw new CustomException(ErrorMessage.INTERNAL_SERVER_ERROR);
         }
@@ -52,7 +52,7 @@ public class DatabaseLockManager implements LockManager {
 
         try (PreparedStatement stmt = connection.prepareStatement(sql)) {
             stmt.setString(1, key);
-            stmt.executeQuery(); // 락 key 해제
+            stmt.executeQuery();
         } catch (SQLException e) {
             throw new CustomException(ErrorMessage.INTERNAL_SERVER_ERROR);
         }

--- a/src/main/java/org/pingle/pingleserver/service/lock/DatabaseLockManager.java
+++ b/src/main/java/org/pingle/pingleserver/service/lock/DatabaseLockManager.java
@@ -1,0 +1,60 @@
+package org.pingle.pingleserver.service.lock;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.pingle.pingleserver.dto.type.ErrorMessage;
+import org.pingle.pingleserver.exception.CustomException;
+import org.pingle.pingleserver.service.LockManager;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DatabaseLockManager implements LockManager {
+
+    private final DataSource lockDataSource;
+
+    public DatabaseLockManager(@Qualifier("lockDataSource") DataSource lockDataSource) {
+        this.lockDataSource = lockDataSource;
+    }
+
+    public void executeWithLock(String key, Runnable runnable) {
+        try (Connection connection = lockDataSource.getConnection()) {
+            try {
+                getLock(connection, key);
+                runnable.run();
+            } finally {
+                releaseLock(connection, key);
+            }
+        } catch (SQLException e) {
+            throw new CustomException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private void getLock(final Connection connection, final String key) {
+        String sql = "SELECT get_lock(?, ?)";
+
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, key);
+            stmt.setInt(2, 3000);
+            stmt.executeQuery(); // 락 key 획득 시도, 무한 대기
+        } catch (SQLException e) {
+            throw new CustomException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private void releaseLock(
+            final Connection connection,
+            final String key
+    ) {
+        String sql = "SELECT RELEASE_LOCK(?)";
+
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, key);
+            stmt.executeQuery(); // 락 key 해제
+        } catch (SQLException e) {
+            throw new CustomException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/org/pingle/pingleserver/service/lock/DatabaseLockManager.java
+++ b/src/main/java/org/pingle/pingleserver/service/lock/DatabaseLockManager.java
@@ -44,10 +44,7 @@ public class DatabaseLockManager implements LockManager {
         }
     }
 
-    private void releaseLock(
-            final Connection connection,
-            final String key
-    ) {
+    private void releaseLock(final Connection connection, final String key) {
         String sql = "SELECT RELEASE_LOCK(?)";
 
         try (PreparedStatement stmt = connection.prepareStatement(sql)) {

--- a/src/test/java/org/pingle/pingleserver/PingleserverApplicationTests.java
+++ b/src/test/java/org/pingle/pingleserver/PingleserverApplicationTests.java
@@ -2,8 +2,10 @@ package org.pingle.pingleserver;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class PingleserverApplicationTests {
 
 	@Test

--- a/src/test/java/org/pingle/pingleserver/ServiceSliceTest.java
+++ b/src/test/java/org/pingle/pingleserver/ServiceSliceTest.java
@@ -1,0 +1,14 @@
+package org.pingle.pingleserver;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.pingle.pingleserver.util.DatabaseCleanerExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ActiveProfiles;
+
+@ExtendWith(DatabaseCleanerExtension.class)
+@SpringBootTest(webEnvironment = WebEnvironment.MOCK)
+@ActiveProfiles("test")
+public abstract class ServiceSliceTest {
+}
+

--- a/src/test/java/org/pingle/pingleserver/fixture/MeetingFixture.java
+++ b/src/test/java/org/pingle/pingleserver/fixture/MeetingFixture.java
@@ -1,0 +1,15 @@
+package org.pingle.pingleserver.fixture;
+
+import java.time.LocalDateTime;
+import org.pingle.pingleserver.domain.Meeting;
+import org.pingle.pingleserver.domain.Pin;
+import org.pingle.pingleserver.domain.enums.MCategory;
+
+public abstract class MeetingFixture {
+    private MeetingFixture() {
+    }
+
+    public static Meeting create(Pin pin, int maxParticipants , LocalDateTime start, LocalDateTime end) {
+        return new Meeting(pin, MCategory.MULTI, "name", maxParticipants, "link", start, end);
+    }
+}

--- a/src/test/java/org/pingle/pingleserver/fixture/PinFixture.java
+++ b/src/test/java/org/pingle/pingleserver/fixture/PinFixture.java
@@ -1,0 +1,15 @@
+package org.pingle.pingleserver.fixture;
+
+import org.pingle.pingleserver.domain.Address;
+import org.pingle.pingleserver.domain.Pin;
+import org.pingle.pingleserver.domain.Point;
+import org.pingle.pingleserver.domain.Team;
+
+public abstract class PinFixture {
+    private PinFixture() {
+    }
+
+    public static Pin create(Team team) {
+        return new Pin(team, new Point(1.0, 1.0), new Address("add1", "add2"), "name");
+    }
+}

--- a/src/test/java/org/pingle/pingleserver/fixture/TeamFixture.java
+++ b/src/test/java/org/pingle/pingleserver/fixture/TeamFixture.java
@@ -1,0 +1,13 @@
+package org.pingle.pingleserver.fixture;
+
+import org.pingle.pingleserver.domain.Team;
+import org.pingle.pingleserver.domain.enums.TKeyword;
+
+public abstract class TeamFixture {
+    private TeamFixture() {
+    }
+
+    public static Team create() {
+        return new Team("team1", "team1", "code", TKeyword.ETC);
+    }
+}

--- a/src/test/java/org/pingle/pingleserver/fixture/UserFixture.java
+++ b/src/test/java/org/pingle/pingleserver/fixture/UserFixture.java
@@ -1,0 +1,14 @@
+package org.pingle.pingleserver.fixture;
+
+import org.pingle.pingleserver.domain.User;
+import org.pingle.pingleserver.domain.enums.Provider;
+import org.pingle.pingleserver.domain.enums.URole;
+
+public abstract class UserFixture {
+    private UserFixture() {
+    }
+
+    public static User create() {
+        return new User("serial", "name", "email", Provider.APPLE, URole.USER, "refreshToken");
+    }
+}

--- a/src/test/java/org/pingle/pingleserver/service/MeetingParticipateFacadeTest.java
+++ b/src/test/java/org/pingle/pingleserver/service/MeetingParticipateFacadeTest.java
@@ -1,0 +1,132 @@
+package org.pingle.pingleserver.service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.pingle.pingleserver.ServiceSliceTest;
+import org.pingle.pingleserver.domain.Meeting;
+import org.pingle.pingleserver.domain.Pin;
+import org.pingle.pingleserver.domain.Team;
+import org.pingle.pingleserver.domain.User;
+import org.pingle.pingleserver.exception.CustomException;
+import org.pingle.pingleserver.fixture.MeetingFixture;
+import org.pingle.pingleserver.fixture.PinFixture;
+import org.pingle.pingleserver.fixture.TeamFixture;
+import org.pingle.pingleserver.fixture.UserFixture;
+import org.pingle.pingleserver.repository.MeetingRepository;
+import org.pingle.pingleserver.repository.PinRepository;
+import org.pingle.pingleserver.repository.TeamRepository;
+import org.pingle.pingleserver.repository.UserMeetingRepository;
+import org.pingle.pingleserver.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class MeetingParticipateFacadeTest extends ServiceSliceTest {
+
+    @Autowired
+    private MeetingParticipateFacade meetingParticipateFacade;
+    @Autowired
+    private MeetingRepository meetingRepository;
+    @Autowired
+    private TeamRepository teamRepository;
+    @Autowired
+    private PinRepository pinRepository;
+    @Autowired
+    private UserMeetingRepository userMeetingRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("동시에 발생하는 번개 참여에 대해 최대 인원수만큼만 허가한다.")
+    void participateMeetingConcurrently() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+        // given
+        Meeting meeting = createMeeting();
+        for (int i = 0; i < threadCount; i++) {
+            userRepository.save(UserFixture.create());
+        }
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            long userId = i + 1;
+            Future<?> submit = executorService.submit(() -> {
+                try {
+                    meetingParticipateFacade.participateWithLock(userId, meeting.getId());
+                } finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+        countDownLatch.await();
+
+        // then
+        int currentParticipantsSize = userMeetingRepository.findAllByMeeting(meeting).size();
+        Assertions.assertThat(currentParticipantsSize).isEqualTo(meeting.getMaxParticipants());
+    }
+
+    @Test
+    @DisplayName("번개에 참여하면 참여자로 등록된다.")
+    void participateMeeting() {
+        // given
+        Meeting meeting = createMeeting();
+        meetingRepository.save(meeting);
+
+        User user = UserFixture.create();
+        userRepository.save(user);
+        // when
+        meetingParticipateFacade.participateWithLock(user.getId(), meeting.getId());
+        // then
+        Assertions.assertThat(userMeetingRepository.existsByUserIdAndMeeting(user.getId(), meeting)).isTrue();
+        Assertions.assertThat(userMeetingRepository.findAllByMeeting(meeting)).hasSize(1);
+    }
+
+    private Meeting createMeeting() {
+        Team team = teamRepository.save(TeamFixture.create());
+        Pin pin = pinRepository.save(PinFixture.create(team));
+        return meetingRepository.save(MeetingFixture.create(pin, 10, LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1)));
+    }
+
+    @Test
+    @DisplayName("동일한 참여자가 같은 번개에 동시에 중복 참여하면 예외를 발생한다.")
+    void failParticipateMeetingOnDuplicateConcurrently() throws InterruptedException {
+        // given
+        Meeting meeting = createMeeting();
+        meetingRepository.save(meeting);
+
+        User user = UserFixture.create();
+        userRepository.save(user);
+
+        int THREAD_COUNT = 2;
+        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+        CountDownLatch countDownLatch = new CountDownLatch(THREAD_COUNT);
+        // when
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            futures.add(executorService.submit(() -> {
+                try {
+                    meetingParticipateFacade.participateWithLock(user.getId(), meeting.getId());
+                    return null;
+                } finally {
+                    countDownLatch.countDown();
+                }
+            }));
+        }
+        countDownLatch.await();
+        // then
+        Assertions.assertThatThrownBy(() -> {
+            for (Future<?> future : futures) {
+                future.get();
+            }
+        }).isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(CustomException.class);
+    }
+}

--- a/src/test/java/org/pingle/pingleserver/service/UserMeetingServiceTest.java
+++ b/src/test/java/org/pingle/pingleserver/service/UserMeetingServiceTest.java
@@ -1,0 +1,117 @@
+package org.pingle.pingleserver.service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.pingle.pingleserver.ServiceSliceTest;
+import org.pingle.pingleserver.domain.Meeting;
+import org.pingle.pingleserver.domain.Pin;
+import org.pingle.pingleserver.domain.Team;
+import org.pingle.pingleserver.domain.User;
+import org.pingle.pingleserver.exception.CustomException;
+import org.pingle.pingleserver.fixture.MeetingFixture;
+import org.pingle.pingleserver.fixture.PinFixture;
+import org.pingle.pingleserver.fixture.TeamFixture;
+import org.pingle.pingleserver.fixture.UserFixture;
+import org.pingle.pingleserver.repository.MeetingRepository;
+import org.pingle.pingleserver.repository.PinRepository;
+import org.pingle.pingleserver.repository.TeamRepository;
+import org.pingle.pingleserver.repository.UserMeetingRepository;
+import org.pingle.pingleserver.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class UserMeetingServiceTest extends ServiceSliceTest {
+    @Autowired
+    private UserMeetingService userMeetingService;
+    @Autowired
+    private MeetingRepository meetingRepository;
+    @Autowired
+    private TeamRepository teamRepository;
+    @Autowired
+    private PinRepository pinRepository;
+    @Autowired
+    private UserMeetingRepository userMeetingRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("번개에 참여하면 참여자로 등록된다.")
+    void participateMeeting() {
+        // given
+        Meeting meeting = createMeeting();
+        meetingRepository.save(meeting);
+
+        User user = UserFixture.create();
+        userRepository.save(user);
+        // when
+        userMeetingService.participateMeeting(user.getId(), meeting.getId());
+        // then
+        Assertions.assertThat(userMeetingRepository.existsByUserIdAndMeeting(user.getId(), meeting)).isTrue();
+        Assertions.assertThat(userMeetingRepository.findAllByMeeting(meeting)).hasSize(1);
+    }
+
+    private Meeting createMeeting() {
+        Team team = teamRepository.save(TeamFixture.create());
+        Pin pin = pinRepository.save(PinFixture.create(team));
+        return meetingRepository.save(MeetingFixture.create(pin, 10, LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1)));
+    }
+
+    @Test
+    @DisplayName("번개에 참여자가 중복 참여하면 예외를 발생한다.")
+    void failParticipateMeetingOnDuplicate() {
+        // given
+        Meeting meeting = createMeeting();
+        meetingRepository.save(meeting);
+
+        User user = UserFixture.create();
+        userRepository.save(user);
+
+        userMeetingService.participateMeeting(user.getId(), meeting.getId());
+        // when
+        Assertions.assertThatThrownBy(() -> userMeetingService.participateMeeting(user.getId(), meeting.getId()))
+                .isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    @DisplayName("동일한 참여자가 같은 번개에 동시에 중복 참여하면 예외를 발생한다.")
+    void failParticipateMeetingOnDuplicateConcurrently() throws InterruptedException {
+        // given
+        Meeting meeting = createMeeting();
+        meetingRepository.save(meeting);
+
+        User user = UserFixture.create();
+        userRepository.save(user);
+
+        int THREAD_COUNT = 2;
+        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+        CountDownLatch countDownLatch = new CountDownLatch(THREAD_COUNT);
+        // when
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            futures.add(executorService.submit(() -> {
+                try {
+                    userMeetingService.participateMeeting(user.getId(), meeting.getId());
+                    return null;
+                } finally {
+                    countDownLatch.countDown();
+                }
+            }));
+        }
+        countDownLatch.await();
+        // then
+        Assertions.assertThatThrownBy(() -> {
+                    for (Future<?> future : futures) {
+                        future.get();
+                    }
+                }).isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(CustomException.class);
+    }
+}

--- a/src/test/java/org/pingle/pingleserver/util/DatabaseCleaner.java
+++ b/src/test/java/org/pingle/pingleserver/util/DatabaseCleaner.java
@@ -1,0 +1,55 @@
+package org.pingle.pingleserver.util;
+
+import java.util.List;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Table;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class DatabaseCleaner {
+    @Autowired
+    private EntityManager entityManager;
+
+    @Transactional
+    public void cleanUp() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = FALSE").executeUpdate();
+        for (String tableName : getTableNames()) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+//            entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN " + tableName + "_ID" + " RESTART WITH 1")
+//                    .executeUpdate();
+        }
+        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = TRUE").executeUpdate();
+    }
+
+    private List<String> getTableNames() {
+        return entityManager.getMetamodel().getEntities().stream()
+                .filter(entity -> entity.getJavaType().isAnnotationPresent(Entity.class))
+                .map(entityType -> {
+                    Table tableAnnotation = entityType.getJavaType().getAnnotation(Table.class);
+                    if (tableAnnotation != null && !tableAnnotation.name().isBlank()) {
+                        return tableAnnotation.name();
+                    } else {
+                        return camelToSnake(entityType.getName());
+                    }
+                })
+                .toList();
+    }
+
+    private String camelToSnake(String camel) {
+        StringBuilder snake = new StringBuilder();
+        for (char c : camel.toCharArray()) {
+            if (Character.isUpperCase(c)) {
+                snake.append("_");
+            }
+            snake.append(Character.toLowerCase(c));
+        }
+        if (snake.charAt(0) == '_') {
+            snake.deleteCharAt(0);
+        }
+        return snake.toString();
+    }
+}

--- a/src/test/java/org/pingle/pingleserver/util/DatabaseCleanerExtension.java
+++ b/src/test/java/org/pingle/pingleserver/util/DatabaseCleanerExtension.java
@@ -1,0 +1,13 @@
+package org.pingle.pingleserver.util;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class DatabaseCleanerExtension implements BeforeEachCallback {
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        DatabaseCleaner databaseCleaner = SpringExtension.getApplicationContext(context).getBean(DatabaseCleaner.class);
+        databaseCleaner.cleanUp();
+    }
+}


### PR DESCRIPTION
## Related Issue 📌
- close #130 

## Description ✔️
- mysql named lock을 사용하여 분산락 구현
- hikari cp 데드락을 회피하기 위한 cp 분리
- 데이터베이스 세션 유지를 위한 jdbc 사용(transaction x)
- 중복 참가를 제한하기 위한 유니크 키 도입

## To Reviewers
